### PR TITLE
correcting the gem dewpoint call

### DIFF
--- a/src/routes/en/docs/gem-api/+page.svelte
+++ b/src/routes/en/docs/gem-api/+page.svelte
@@ -13,7 +13,7 @@ onMount(async () => {
 
 const pressureVariables = [
     {name: "temperature", label: "Temperature"},
-    {name: "dewoint", label: "Dewpooint"},
+    {name: "dewpoint", label: "Dewpoint"},
     {name: "relativehumidity", label: "Relative Humidity"},
     {name: "cloudcover", label: "Cloudcover"},
     {name: "windspeed", label: "Wind Speed"},


### PR DESCRIPTION
initial error when calling the dewpoint in 10hPa :  https://open-meteo.com/en/docs/gem-api

[url](https://api.open-meteo.com/v1/gem?latitude=35.678&longitude=139.682&hourly=temperature_2m,shortwave_radiation,direct_radiation,diffuse_radiation,direct_normal_irradiance,terrestrial_radiation,shortwave_radiation_instant,direct_radiation_instant,diffuse_radiation_instant,direct_normal_irradiance_instant,terrestrial_radiation_instant,temperature_10hPa,dewoint_10hPa,relativehumidity_10hPa,cloudcover_10hPa,windspeed_10hPa,winddirection_10hPa,geopotential_height_10hPa&timeformat=unixtime)



API error: Cannot initialize VariableOrDerived<SurfaceAndPressureVariable<GemSurfaceVariable, GemPressureVariable>, SurfaceAndPressureVariable<GemVariableDerivedSurface, GemPressureVariableDerived>> from invalid String value dewoint_10hPa for key 