### PR TITLE
removing windgusts_10m_max from jma api

### DIFF
--- a/src/routes/en/docs/dwd-api/+page.svelte
+++ b/src/routes/en/docs/dwd-api/+page.svelte
@@ -1205,12 +1205,6 @@ const levels = [30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 85
               increases. For low VPD (&lt;0.4), transpiration decreases</td>
           </tr>
           <tr>
-            <th scope="row">cape</th>
-            <td>Instant</td>
-            <td>J/kg</td>
-            <td>Convective available potential energy. See <a href="https://en.wikipedia.org/wiki/Convective_available_potential_energy" target="_blank">Wikipedia</a>.</td>
-          </tr>
-          <tr>
             <th scope="row">lightning_potential</th>
             <td>Instant</td>
             <td>J/kg</td>

--- a/src/routes/en/docs/dwd-api/+page.svelte
+++ b/src/routes/en/docs/dwd-api/+page.svelte
@@ -995,7 +995,7 @@ const levels = [30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 85
             <td>No</td>
             <td></td>
             <td>A list of weather variables which should be returned. Values can be comma separated, or multiple
-              <mark>&minutely_15=</mark> parameter in the URL can be used.
+              <mark>&hourly=</mark> parameter in the URL can be used.
             </td>
           </tr>
           <tr>
@@ -1004,7 +1004,7 @@ const levels = [30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 85
             <td>No</td>
             <td></td>
             <td>A list of weather variables which should be returned. Values can be comma separated, or multiple
-              <mark>&hourly=</mark> parameter in the URL can be used.
+              <mark>&minutely_15=</mark> parameter in the URL can be used.
             </td>
           </tr>
           <tr>

--- a/src/routes/en/docs/dwd-api/+page.svelte
+++ b/src/routes/en/docs/dwd-api/+page.svelte
@@ -995,6 +995,15 @@ const levels = [30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 85
             <td>No</td>
             <td></td>
             <td>A list of weather variables which should be returned. Values can be comma separated, or multiple
+              <mark>&minutely_15=</mark> parameter in the URL can be used.
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">minutely_15</th>
+            <td>String array</td>
+            <td>No</td>
+            <td></td>
+            <td>A list of weather variables which should be returned. Values can be comma separated, or multiple
               <mark>&hourly=</mark> parameter in the URL can be used.
             </td>
           </tr>

--- a/src/routes/en/docs/jma-api/+page.svelte
+++ b/src/routes/en/docs/jma-api/+page.svelte
@@ -968,11 +968,6 @@ const levels = [1000, 925, 850, 700, 500, 400, 300, 250, 200, 150, 100]
             <td>Sun rise and set times</td>
           </tr>
           <tr>
-            <th scope="row">windspeed_10m_max<br />windgusts_10m_max</th>
-            <td>km/h (mph, m/s, knots)</td>
-            <td>Maximum wind speed and gusts on a day</td>
-          </tr>
-          <tr>
             <th scope="row">winddirection_10m_dominant</th>
             <td>°</td>
             <td>Dominant wind direction</td>


### PR DESCRIPTION
url : https://api.open-meteo.com/v1/jma?latitude=35.678&longitude=139.682&daily=windgusts_10m_max&timezone=auto&timeformat=unixtime

error : "Cannot initialize JmaDailyWeatherVariable from invalid String value windgusts_10m_max for key "