### PR TITLE
fix: Revert "bump highcharts from 11.3.0 to 11.4.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "open-meteo-website",
 			"version": "0.0.1",
 			"dependencies": {
-				"highcharts": "^11.4.0",
+				"highcharts": "^11.3.0",
 				"openmeteo": "^1.1.3",
 				"svelte-local-storage-store": "^0.6.4",
 				"svelty-picker": "^5.2.6"
@@ -2828,9 +2828,9 @@
 			}
 		},
 		"node_modules/highcharts": {
-			"version": "11.4.0",
-			"resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.4.0.tgz",
-			"integrity": "sha512-f5POJz2WdHW6SNT4P2CoMjsgcX5F5sJXtdfWLQCaNP9JG0nG5TSGG7+A6vzHGzcDkTPM72EQbRQofNZHaRTUPg=="
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.3.0.tgz",
+			"integrity": "sha512-Dk+Qfk/xit8KnXKPDxmcVcq48ZlcVSq7oYJR5VZlAVWnJ0BY3JFFi1GOvgSNUzlh2wzsfenihWpkAkWoag4Xqg=="
 		},
 		"node_modules/highlight.js": {
 			"version": "10.7.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"highcharts": "^11.4.0",
+		"highcharts": "^11.3.0",
 		"openmeteo": "^1.1.3",
 		"svelte-local-storage-store": "^0.6.4",
 		"svelty-picker": "^5.2.6"


### PR DESCRIPTION
Reverts open-meteo/open-meteo-website#182