### PR TITLE
fix: incorrect labels for azimuth, tilt, and past_minutely_15

### DIFF
--- a/src/routes/en/docs/+page.svelte
+++ b/src/routes/en/docs/+page.svelte
@@ -551,7 +551,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -572,7 +572,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/+page.svelte
+++ b/src/routes/en/docs/+page.svelte
@@ -752,7 +752,7 @@
 						<select
 							class="form-select"
 							name="past_minutely_15"
-							id="past_minutely_15s"
+							id="past_minutely_15"
 							aria-label="Past Minutely 15 Steps"
 							bind:value={$params.past_minutely_15}
 						>

--- a/src/routes/en/docs/bom-api/+page.svelte
+++ b/src/routes/en/docs/bom-api/+page.svelte
@@ -406,7 +406,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -427,7 +427,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/cma-api/+page.svelte
+++ b/src/routes/en/docs/cma-api/+page.svelte
@@ -443,7 +443,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -464,7 +464,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/dwd-api/+page.svelte
+++ b/src/routes/en/docs/dwd-api/+page.svelte
@@ -484,7 +484,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -505,7 +505,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/dwd-api/+page.svelte
+++ b/src/routes/en/docs/dwd-api/+page.svelte
@@ -659,7 +659,7 @@
 						<select
 							class="form-select"
 							name="past_minutely_15"
-							id="past_minutely_15s"
+							id="past_minutely_15"
 							aria-label="Past Minutely 15 Steps"
 							bind:value={$params.past_minutely_15}
 						>

--- a/src/routes/en/docs/ecmwf-api/+page.svelte
+++ b/src/routes/en/docs/ecmwf-api/+page.svelte
@@ -385,7 +385,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -406,7 +406,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/ensemble-api/+page.svelte
+++ b/src/routes/en/docs/ensemble-api/+page.svelte
@@ -654,7 +654,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -675,7 +675,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/gem-api/+page.svelte
+++ b/src/routes/en/docs/gem-api/+page.svelte
@@ -437,7 +437,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -458,7 +458,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/gfs-api/+page.svelte
+++ b/src/routes/en/docs/gfs-api/+page.svelte
@@ -665,7 +665,7 @@
 						<select
 							class="form-select"
 							name="past_minutely_15"
-							id="past_minutely_15s"
+							id="past_minutely_15"
 							aria-label="Past Minutely 15 Steps"
 							bind:value={$params.past_minutely_15}
 						>

--- a/src/routes/en/docs/gfs-api/+page.svelte
+++ b/src/routes/en/docs/gfs-api/+page.svelte
@@ -493,7 +493,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -514,7 +514,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/historical-forecast-api/+page.svelte
+++ b/src/routes/en/docs/historical-forecast-api/+page.svelte
@@ -414,7 +414,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -435,7 +435,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/historical-weather-api/+page.svelte
+++ b/src/routes/en/docs/historical-weather-api/+page.svelte
@@ -343,7 +343,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -364,7 +364,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/jma-api/+page.svelte
+++ b/src/routes/en/docs/jma-api/+page.svelte
@@ -414,7 +414,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -435,7 +435,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/meteofrance-api/+page.svelte
+++ b/src/routes/en/docs/meteofrance-api/+page.svelte
@@ -480,7 +480,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -501,7 +501,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/meteofrance-api/+page.svelte
+++ b/src/routes/en/docs/meteofrance-api/+page.svelte
@@ -635,7 +635,7 @@
 						<select
 							class="form-select"
 							name="past_minutely_15"
-							id="past_minutely_15s"
+							id="past_minutely_15"
 							aria-label="Past Minutely 15 Steps"
 							bind:value={$params.past_minutely_15}
 						>

--- a/src/routes/en/docs/metno-api/+page.svelte
+++ b/src/routes/en/docs/metno-api/+page.svelte
@@ -367,7 +367,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -388,7 +388,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)

--- a/src/routes/en/docs/previous-runs-api/+page.svelte
+++ b/src/routes/en/docs/previous-runs-api/+page.svelte
@@ -359,7 +359,7 @@
 							max="90"
 							bind:value={$params.tilt}
 						/>
-						<label for="latitude">Panel Tilt (0° horizontal)</label>
+						<label for="tilt">Panel Tilt (0° horizontal)</label>
 						{#if $params.tilt < 0 ||$params.tilt > 90 }
 							<div class="invalid-tooltip" transition:slide>
 								Tilt must be between 0° and 90°
@@ -380,7 +380,7 @@
 							max="90"
 							bind:value={$params.azimuth}
 						/>
-						<label for="latitude">Panel Azimuth (0° S, -90° E, 90° W)</label>
+						<label for="azimuth">Panel Azimuth (0° S, -90° E, 90° W)</label>
 						{#if Number($params.azimuth) < -180 || Number($params.azimuth) > 180 }
 							<div class="invalid-tooltip" transition:slide>
 								Azimuth must be between -90° (east) and 90° (west)


### PR DESCRIPTION
I've found several cases where the `<label for="...">` tag doesn't match the form element it's supposed to match. This fixes it.
