### PR TITLE
feat: Sea level height including ocean tides

### DIFF
--- a/src/routes/en/docs/marine-weather-api/+page.svelte
+++ b/src/routes/en/docs/marine-weather-api/+page.svelte
@@ -13,13 +13,16 @@
 	import CalendarEvent from 'svelte-bootstrap-icons/lib/CalendarEvent.svelte';
 	import Clock from 'svelte-bootstrap-icons/lib/Clock.svelte';
 
-	import { daily, hourly, models, defaultParameters, additionalVariables } from './options';
+	import { daily, hourly, models, defaultParameters, additionalVariables, minutely_15 } from './options';
 
 	const params = urlHashStore({
 		latitude: [54.544587],
 		longitude: [10.227487],
 		...defaultParameters,
-		hourly: ['wave_height']
+		hourly: ['wave_height'],
+		minutely_15: [],
+		past_minutely_15: '',
+		forecast_minutely_15: '',
 	});
 
 	let timezoneInvalid = $derived($params.timezone == 'UTC' && $params.daily.length > 0);
@@ -260,6 +263,76 @@
 							<option value="native">Native Model Resolution</option>
 						</select>
 						<label for="temporal_resolution">Temporal Resolution For Hourly Data</label>
+					</div>
+				</div>
+			</AccordionItem>
+			<AccordionItem
+				id="minutely_15"
+				title="15-Minutely Weather Variables"
+				count={countVariables(minutely_15, $params.hourly)}
+			>
+				{#each minutely_15 as group}
+					<div class="col-md-6 mb-3">
+						{#each group as e}
+							<div class="form-check">
+								<input
+									class="form-check-input"
+									type="checkbox"
+									value={e.name}
+									id="{e.name}_minutely_15"
+									name="minutely_15"
+									bind:group={$params.minutely_15}
+								/>
+								<label class="form-check-label" for="{e.name}_minutely_15">{e.label}</label>
+							</div>
+						{/each}
+					</div>
+				{/each}
+				<div class="col-md-12 mb-3">
+					<small class="text-muted"
+						>Note: Only interpolated data from 1-hourly values.</small
+					>
+				</div>
+				<div class="col-md-12 mb-3">
+					<small class="text-muted"
+						>Note: You can further adjust the forecast time range for 15-minutely weather variables
+						using <mark>&forecast_minutely_15=</mark> and <mark>&past_minutely_15=</mark> as shown below.
+					</small>
+				</div>
+				<div class="col-md-3">
+					<div class="form-floating mb-3">
+						<select
+							class="form-select"
+							name="forecast_minutely_15"
+							id="forecast_minutely_15"
+							aria-label="Forecast Minutely 15 Steps"
+							bind:value={$params.forecast_minutely_15}
+						>
+							<option value="">- (default)</option>
+							<option value="4">1 hour</option>
+							<option value="24">6 hours</option>
+							<option value="48">12 hours</option>
+							<option value="96">24 hours</option>
+						</select>
+						<label for="forecast_minutely_15">Forecast Minutely 15</label>
+					</div>
+				</div>
+				<div class="col-md-3">
+					<div class="form-floating mb-3">
+						<select
+							class="form-select"
+							name="past_minutely_15"
+							id="past_minutely_15"
+							aria-label="Past Minutely 15 Steps"
+							bind:value={$params.past_minutely_15}
+						>
+							<option value="">- (default)</option>
+							<option value="1">1 hour</option>
+							<option value="6">6 hours</option>
+							<option value="12">12 hours</option>
+							<option value="24">24 hours</option>
+						</select>
+						<label for="past_minutely_15">Past Minutely 15</label>
 					</div>
 				</div>
 			</AccordionItem>

--- a/src/routes/en/docs/marine-weather-api/+page.svelte
+++ b/src/routes/en/docs/marine-weather-api/+page.svelte
@@ -172,8 +172,8 @@
 		<div class="col-md-12 mb-3">
 			<p>
 				<small class="text-muted"
-					>Note: Ocean currents consider Eulerian, Waves and Tides at 0.08° (~8 km) resolution. This
-					is not suitable for small scale currents and does not replace your nautical almanac.
+					>Note: Tides and ocean currents are computed at 0.08° (~8 km) resolution using numerical models. Accuracy at coastal areas is limited. This
+					is not suitable for coastal navigation and does not replace your nautical almanac. Use with caution!
 				</small>
 			</p>
 		</div>
@@ -520,7 +520,7 @@
 				<th scope="row"
 					><a
 						href="https://data.marine.copernicus.eu/product/GLOBAL_ANALYSISFORECAST_PHY_001_024/services"
-						>MeteoFrance SMOC Currents</a
+						>MeteoFrance SMOC Currents, Tides & SST</a
 					>
 				</th>
 				<td>Global</td>
@@ -852,6 +852,30 @@
 					<td
 						>Direction following the flow of the current. E.g. where the current is heading towards.
 						0° = Going north; 90° = Towards east.</td
+					>
+				</tr>
+				<tr>
+					<th scope="row">sea_surface_temperature</th>
+					<td>Instant</td>
+					<td>Celsius</td>
+					<td
+						>The sea surface temperature close to the water surface</td
+					>
+				</tr>
+				<tr>
+					<th scope="row">sea_level_height_msl</th>
+					<td>Instant</td>
+					<td>metre</td>
+					<td
+						>The sea level height accounts for ocean tides, the inverted barometer effect, sea surface height, global mean steric variation, and global mean mass volume variation. The reference (datum) height is the global mean sea level, not the lowest astronomical tide. Accuracy is limited in coastal areas—while it can be reasonably accurate near unobstructed coasts, it may be completely unreliable further inland. This data is not suitable for coastal navigation.</td
+					>
+				</tr>
+				<tr>
+					<th scope="row">invert_barometer_height</th>
+					<td>Instant</td>
+					<td>metre</td>
+					<td
+						>Invert barometer effect is the height low and high pressure systems effect the sea level height. This is already considered in <mark>sea_level_height_msl</mark></td
 					>
 				</tr>
 			</tbody>

--- a/src/routes/en/docs/marine-weather-api/options.ts
+++ b/src/routes/en/docs/marine-weather-api/options.ts
@@ -39,7 +39,8 @@ export const hourly = [
 	],
 	[
 		{ name: 'ocean_current_velocity', label: 'Ocean Current Velocity' },
-		{ name: 'ocean_current_direction', label: 'Ocean Current Direction' }
+		{ name: 'ocean_current_direction', label: 'Ocean Current Direction' },
+		{ name: 'sea_level_height_msl', label: 'Sea Level Height including tides (above global mean sea level)' },
 	]
 ];
 
@@ -64,7 +65,9 @@ export const daily = [
 ];
 
 export const additionalVariables = [
-	[{ name: 'wave_peak_period', label: 'Wave Peak Period (ERA5 only)' }],
+	[{ name: 'wave_peak_period', label: 'Wave Peak Period (ERA5 only)' },
+		{ name: 'invert_barometer_height', label: 'Inverted Barometer Height' }
+	],
 	[]
 ];
 

--- a/src/routes/en/docs/marine-weather-api/options.ts
+++ b/src/routes/en/docs/marine-weather-api/options.ts
@@ -41,6 +41,7 @@ export const hourly = [
 		{ name: 'ocean_current_velocity', label: 'Ocean Current Velocity' },
 		{ name: 'ocean_current_direction', label: 'Ocean Current Direction' },
 		{ name: 'sea_level_height_msl', label: 'Sea Level Height including tides (above global mean sea level)' },
+		{ name: 'sea_surface_temperature', label: 'Sea Surface Temperature' },
 	]
 ];
 

--- a/src/routes/en/docs/marine-weather-api/options.ts
+++ b/src/routes/en/docs/marine-weather-api/options.ts
@@ -45,6 +45,15 @@ export const hourly = [
 	]
 ];
 
+export const minutely_15 = [
+	[
+		{ name: 'ocean_current_velocity', label: 'Ocean Current Velocity' },
+		{ name: 'ocean_current_direction', label: 'Ocean Current Direction' },
+	],
+	[
+		{ name: 'sea_level_height_msl', label: 'Sea Level Height including tides (above global mean sea level)' },
+	]
+];
 export const daily = [
 	[
 		{ name: 'wave_height_max', label: 'Wave Height Max' },

--- a/src/routes/en/docs/marine-weather-api/options.ts
+++ b/src/routes/en/docs/marine-weather-api/options.ts
@@ -41,7 +41,7 @@ export const hourly = [
 		{ name: 'ocean_current_velocity', label: 'Ocean Current Velocity' },
 		{ name: 'ocean_current_direction', label: 'Ocean Current Direction' },
 		{ name: 'sea_level_height_msl', label: 'Sea Level Height including tides (above global mean sea level)' },
-		{ name: 'sea_surface_temperature', label: 'Sea Surface Temperature' },
+		{ name: 'sea_surface_temperature', label: 'Sea Surface Temperature SST' },
 	]
 ];
 


### PR DESCRIPTION
Integrate sea level height considering ocean tides.

Important: Ocean tides use the field "total_sea_level" which is the height above the global mean sea level.
This is not the height above lowest atmospherical tide LAT which is usually used in navigation.
To estimate the LAT, we can compute the minimum of "total_sea_level - invert_barometer" over 2.5 years. Ideal would be 18 years.

![Screenshot 2025-02-10 at 17 42 43](https://github.com/user-attachments/assets/0013127e-8d87-457b-9e46-cade8d228bf7)
