### PR TITLE
fix: ECMWF table rows historical forecast

### DIFF
--- a/src/routes/en/docs/historical-forecast-api/+page.svelte
+++ b/src/routes/en/docs/historical-forecast-api/+page.svelte
@@ -960,7 +960,7 @@
 						<td>2022-11-13</td>
 					</tr>
 					<tr>
-						<th scope="row" rowspan="4">ECMWF</th>
+						<th scope="row" rowspan="3">ECMWF</th>
 						<td>IFS 0.4°</td>
 						<td>Global</td>
 						<td>0.4° (~44 km)</td>


### PR DESCRIPTION
Fix models table (ECMWF+UK rows):
![imagen](https://github.com/user-attachments/assets/e36fc1ba-ea46-41ef-ad6f-8fd7500c661d)
