### PR TITLE
fix: Correct typescript code generation for response object

### DIFF
--- a/src/lib/components/response/code-examples/typescript-code-example.ts
+++ b/src/lib/components/response/code-examples/typescript-code-example.ts
@@ -98,7 +98,7 @@ ${t ? '\t' : ''}<span class="line"><span style="color:var(--code-preview-foregro
 ${t ? '\t' : ''}<span class="line"></span>`;
 
 	let int64Found = false;
-	for (const section of ['current', 'minutely_15', 'hourly', 'daily', 'six_hourly']) {
+	for (const section of ['current', 'minutely15', 'hourly', 'daily', 'sixHourly']) {
 		const sect = params[section];
 		if (sect) {
 			c += `


### PR DESCRIPTION
Wrong API methods generated on the website for typescript code for `minutely15` and `sixHourly`
`
const minutely_15 = response.minutely_15()!;
`
This PR fix issue of example code generation for typescript code