### PR TITLE
fix: correct API param name, form field names, hash migration, and URL store comparison

### DIFF
--- a/src/lib/components/header/header.svelte
+++ b/src/lib/components/header/header.svelte
@@ -4,8 +4,8 @@
 	import Github from 'simple-icons/icons/github.svg?raw';
 	import X from 'simple-icons/icons/x.svg?raw';
 
-	import Button from '$lib/components/ui/button/button.svelte';
-	import Toggle from '$lib/components/ui/toggle/toggle.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { Toggle } from '$lib/components/ui/toggle';
 
 	import Logo from '$lib/assets/icons/sun.svelte';
 

--- a/src/lib/components/hero/hero.svelte
+++ b/src/lib/components/hero/hero.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Button from '$lib/components/ui/button/button.svelte';
+	import { Button } from '$lib/components/ui/button';
 
 	interface Props {
 		Logo: import('svelte').Snippet;

--- a/src/lib/components/location/location-selection.svelte
+++ b/src/lib/components/location/location-selection.svelte
@@ -6,7 +6,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import * as Select from '$lib/components/ui/select/index';
+	import * as Select from '$lib/components/ui/select';
 
 	import LocationSearch from '$lib/components/location/location-search.svelte';
 

--- a/src/lib/components/pressure/pressure-levels.svelte
+++ b/src/lib/components/pressure/pressure-levels.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { altitudeAboveSeaLevelMeters } from '$lib/utils/meteo';
 
-	import Button from '$lib/components/ui/button/button.svelte';
+	import { Button } from '$lib/components/ui/button';
 
 	let {
 		pressureVariables = [

--- a/src/lib/components/response/code-examples/swift-code-example.ts
+++ b/src/lib/components/response/code-examples/swift-code-example.ts
@@ -4,7 +4,6 @@ import { INT_64_VARIABLES, SECTIONS } from '$lib/constants';
 
 import {
 	acc,
-	br,
 	cmt,
 	empty,
 	fg,

--- a/src/lib/components/response/results-preview.svelte
+++ b/src/lib/components/response/results-preview.svelte
@@ -8,8 +8,8 @@
 	import { membersPerModel } from '$lib/utils/meteo';
 
 	import * as Alert from '$lib/components/ui/alert';
-	import Button from '$lib/components/ui/button/button.svelte';
-	import Input from '$lib/components/ui/input/input.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
 
 	import { pythonCodeExample } from './code-examples/python-code-example';
 	import { swiftCodeExample } from './code-examples/swift-code-example';

--- a/src/lib/components/settings/settings.svelte
+++ b/src/lib/components/settings/settings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Label } from '$lib/components/ui/label';
-	import * as Select from '$lib/components/ui/select/index';
+	import * as Select from '$lib/components/ui/select';
 
 	import { type Parameters } from '$lib/docs';
 

--- a/src/lib/components/time/time-selector.svelte
+++ b/src/lib/components/time/time-selector.svelte
@@ -3,7 +3,7 @@
 
 	import { Button } from '$lib/components/ui/button';
 	import { Label } from '$lib/components/ui/label';
-	import * as Select from '$lib/components/ui/select/index';
+	import * as Select from '$lib/components/ui/select';
 
 	import DatePicker from '$lib/components/date/date-picker.svelte';
 

--- a/src/lib/components/update/update-notification.svelte
+++ b/src/lib/components/update/update-notification.svelte
@@ -3,7 +3,7 @@
 
 	import { updated } from '$app/state';
 
-	import Button from '../ui/button/button.svelte';
+	import { Button } from '$lib/components/ui/button';
 
 	let updateNotificationClicked = $state(false);
 </script>

--- a/src/lib/stores/url-hash-store.ts
+++ b/src/lib/stores/url-hash-store.ts
@@ -37,13 +37,13 @@ export const urlHashStore = (initialValues: Parameters): UrlHashStore => {
 				let defaultValue = defaultValues[key];
 
 				// params key is array
-				if (defaultValue && Array === defaultValue.constructor) {
-					if (JSON.stringify(value) === JSON.stringify(defaultValue)) {
-						if (page.url.searchParams.has(key) && page.url.searchParams.get(key) !== value) {
-							page.url.searchParams.delete(key);
-							changedParams = true;
-						}
-					} else {
+			if (defaultValue && Array === defaultValue.constructor) {
+				if (JSON.stringify(value) === JSON.stringify(defaultValue)) {
+					if (page.url.searchParams.has(key) && page.url.searchParams.get(key) !== value.join(',')) {
+						page.url.searchParams.delete(key);
+						changedParams = true;
+					}
+				} else {
 						let array = value;
 						// remove empty string when array has more then 1 values
 						if (array.length > 1 && array.includes('')) {

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -3,7 +3,7 @@
 
 	import { page } from '$app/state';
 
-	import Button from '$lib/components/ui/button/button.svelte';
+	import { Button } from '$lib/components/ui/button';
 
 	import Logo from '$lib/assets/icons/rain.svelte';
 </script>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,4 +1,3 @@
-//export const ssr = true;
 import Sun from '$lib/assets/icons/sun.svelte';
 
 import type { LayoutLoad } from './$types';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,7 +20,7 @@
 	<link rel="canonical" href="https://open-meteo.com/" />
 	<meta
 		name="description"
-		content="Open-Source ☀️️️️️️️️️️️️️️️️️️️️️️️️️️️️️ Weather API with free access for non-commercial use. No API Key required ✅. Accurate weather forecasts for any location. Open-Meteo provides high-resolution open data ranging from 1 to 11 kilometres from national weather services. With a user-friendly JSON API, integrating weather data has never been easier. Experience the precision and convenience of Open-Meteo's Forecast API for reliable and comprehensive weather information worldwide."
+		content="Open-Source Weather API with free access for non-commercial use. No API Key required. Accurate weather forecasts for any location. Open-Meteo provides high-resolution open data ranging from 1 to 11 kilometres from national weather services. With a user-friendly JSON API, integrating weather data has never been easier. Experience the precision and convenience of Open-Meteo's Forecast API for reliable and comprehensive weather information worldwide."
 	/>
 </svelte:head>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,7 +20,7 @@
 	<link rel="canonical" href="https://open-meteo.com/" />
 	<meta
 		name="description"
-		content="Open-Source Weather API with free access for non-commercial use. No API Key required. Accurate weather forecasts for any location. Open-Meteo provides high-resolution open data ranging from 1 to 11 kilometres from national weather services. With a user-friendly JSON API, integrating weather data has never been easier. Experience the precision and convenience of Open-Meteo's Forecast API for reliable and comprehensive weather information worldwide."
+		content="Open-Source ☀️️️️️️️️️️️️️️️️️️️️️️️️️️️️️ Weather API with free access for non-commercial use. No API Key required ✅. Accurate weather forecasts for any location. Open-Meteo provides high-resolution open data ranging from 1 to 11 kilometres from national weather services. With a user-friendly JSON API, integrating weather data has never been easier. Experience the precision and convenience of Open-Meteo's Forecast API for reliable and comprehensive weather information worldwide."
 	/>
 </svelte:head>
 

--- a/src/routes/en/docs/+layout.svelte
+++ b/src/routes/en/docs/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { browser, dev } from '$app/environment';
-	import { beforeNavigate } from '$app/navigation';
 	import { page } from '$app/state';
 
-	import Button from '$lib/components/ui/button/button.svelte';
+	import { Button } from '$lib/components/ui/button';
 
 	interface Props {
 		children?: import('svelte').Snippet;
@@ -90,18 +90,11 @@
 
 	// Fix for backwards compatibilty with the old url-params store
 	// which used the hash ('#') for cache busting, now replaced with '?'
-	let hashOnLoad = '';
-	beforeNavigate((e) => {
+	onMount(() => {
 		if (browser) {
-			hashOnLoad = window.location.hash;
-			if (hashOnLoad && hashOnLoad.includes('=')) {
-				if (e.to) {
-					e.to.url.search = hashOnLoad.replace('#', '');
-					hashOnLoad = '';
-					setTimeout(() => {
-						window.location.reload();
-					}, 75);
-				}
+			const hash = window.location.hash;
+			if (hash && hash.includes('=')) {
+				window.location.search = hash.replace('#', '');
 			}
 		}
 	});

--- a/src/routes/en/docs/+layout.svelte
+++ b/src/routes/en/docs/+layout.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-import { dev } from '$app/environment';
-import { page } from '$app/state';
+	import { browser, dev } from '$app/environment';
+	import { beforeNavigate } from '$app/navigation';
+	import { page } from '$app/state';
 
-import { Button } from '$lib/components/ui/button';
+	import Button from '$lib/components/ui/button/button.svelte';
 
 	interface Props {
 		children?: import('svelte').Snippet;
@@ -86,6 +87,24 @@ import { Button } from '$lib/components/ui/button';
 	});
 
 	let mobileNavOpened = $state(false);
+
+	// Fix for backwards compatibilty with the old url-params store
+	// which used the hash ('#') for cache busting, now replaced with '?'
+	let hashOnLoad = '';
+	beforeNavigate((e) => {
+		if (browser) {
+			hashOnLoad = window.location.hash;
+			if (hashOnLoad && hashOnLoad.includes('=')) {
+				if (e.to) {
+					e.to.url.search = hashOnLoad.replace('#', '');
+					hashOnLoad = '';
+					setTimeout(() => {
+						window.location.reload();
+					}, 75);
+				}
+			}
+		}
+	});
 </script>
 
 <div class="mb-12 flex flex-col md:mb-24 md:flex-row">

--- a/src/routes/en/docs/+layout.svelte
+++ b/src/routes/en/docs/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { browser, dev } from '$app/environment';
+	import { dev } from '$app/environment';
 	import { page } from '$app/state';
 
 	import { Button } from '$lib/components/ui/button';
@@ -88,14 +88,11 @@
 
 	let mobileNavOpened = $state(false);
 
-	// Fix for backwards compatibilty with the old url-params store
-	// which used the hash ('#') for cache busting, now replaced with '?'
+	// Convert legacy hash-based url-params (cache-busting) to search params
 	onMount(() => {
-		if (browser) {
-			const hash = window.location.hash;
-			if (hash && hash.includes('=')) {
-				window.location.search = hash.replace('#', '');
-			}
+		const hash = window.location.hash;
+		if (hash && hash.includes('=')) {
+			window.location.search = hash.replace('#', '');
 		}
 	});
 </script>

--- a/src/routes/en/docs/+layout.svelte
+++ b/src/routes/en/docs/+layout.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { dev } from '$app/environment';
-	import { page } from '$app/state';
+import { dev } from '$app/environment';
+import { page } from '$app/state';
 
-	import { Button } from '$lib/components/ui/button';
+import { Button } from '$lib/components/ui/button';
 
 	interface Props {
 		children?: import('svelte').Snippet;
@@ -87,14 +86,6 @@
 	});
 
 	let mobileNavOpened = $state(false);
-
-	// Convert legacy hash-based url-params (cache-busting) to search params
-	onMount(() => {
-		const hash = window.location.hash;
-		if (hash && hash.includes('=')) {
-			window.location.search = hash.replace('#', '');
-		}
-	});
 </script>
 
 <div class="mb-12 flex flex-col md:mb-24 md:flex-row">

--- a/src/routes/en/docs/+page.svelte
+++ b/src/routes/en/docs/+page.svelte
@@ -623,7 +623,7 @@
 				<div class="mt-3 grid grid-cols-1 gap-3 md:mt-6 md:grid-cols-2 md:gap-6">
 					<div class="relative">
 						<Select.Root
-							name="cell_selection"
+							name="forecast_minutely_15"
 							type="single"
 							bind:value={$params.forecast_minutely_15}
 						>
@@ -641,7 +641,7 @@
 						</Select.Root>
 					</div>
 					<div class="relative">
-						<Select.Root name="cell_selection" type="single" bind:value={$params.past_minutely_15}>
+						<Select.Root name="past_minutely_15" type="single" bind:value={$params.past_minutely_15}>
 							<Select.Trigger class="data-placeholder:text-foreground h-12 cursor-pointer pt-6"
 								>{pastMinutely15?.label}</Select.Trigger
 							>

--- a/src/routes/en/docs/ensemble-mean-api/+page.svelte
+++ b/src/routes/en/docs/ensemble-mean-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 

--- a/src/routes/en/docs/geocoding-api/+page.svelte
+++ b/src/routes/en/docs/geocoding-api/+page.svelte
@@ -8,9 +8,9 @@
 	import GeocodingError from '$lib/components/code/docs/geocoding-error.svx';
 	import GeocodingObject from '$lib/components/code/docs/geocoding-object.svx';
 
-	import Input from '$lib/components/ui/input/input.svelte';
+	import { Input } from '$lib/components/ui/input';
 	import Label from '$lib/components/ui/label/label.svelte';
-	import * as Select from '$lib/components/ui/select/index';
+	import * as Select from '$lib/components/ui/select';
 
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 

--- a/src/routes/en/docs/gfs-api/+page.svelte
+++ b/src/routes/en/docs/gfs-api/+page.svelte
@@ -21,7 +21,7 @@
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import * as Select from '$lib/components/ui/select/index';
+	import * as Select from '$lib/components/ui/select';
 	import * as ToggleGroup from '$lib/components/ui/toggle-group/index.js';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';

--- a/src/routes/en/docs/historical-weather-api/+page.svelte
+++ b/src/routes/en/docs/historical-weather-api/+page.svelte
@@ -16,7 +16,7 @@
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import * as Select from '$lib/components/ui/select/index';
+	import * as Select from '$lib/components/ui/select';
 	import * as ToggleGroup from '$lib/components/ui/toggle-group/index.js';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';

--- a/src/routes/en/docs/model-updates/+page.svelte
+++ b/src/routes/en/docs/model-updates/+page.svelte
@@ -7,7 +7,7 @@
 
 	import { pad } from '$lib/utils';
 
-	import Button from '$lib/components/ui/button/button.svelte';
+	import { Button } from '$lib/components/ui/button';
 	import { Label } from '$lib/components/ui/label';
 	import { Switch } from '$lib/components/ui/switch';
 

--- a/src/routes/en/docs/options.ts
+++ b/src/routes/en/docs/options.ts
@@ -204,7 +204,7 @@ export const additionalDaily = [
 	],
 	[
 		{ value: 'et0_fao_evapotranspiration_sum', label: 'Reference Evapotranspiration Sum (ET₀)' },
-		{ value: 'growing_degree_days_base_0_limit_50', label: 'Growing Degree Days Base 0 Limit 50 ' },
+		{ value: 'growing_degree_days_base_0_limit_50', label: 'Growing Degree Days Base 0 Limit 50' },
 		{ value: 'leaf_wetness_probability_mean', label: 'Mean Leaf Wetness Probability' },
 		{ value: 'precipitation_probability_mean', label: 'Mean Precipitation Probability' },
 		{ value: 'precipitation_probability_min', label: 'Minimum Precipitation Probability' },
@@ -224,7 +224,7 @@ export const additionalDaily = [
 		{ value: 'visibility_mean', label: 'Mean Visibility' },
 		{ value: 'visibility_min', label: 'Minimum Visibility' },
 		{ value: 'visibility_max', label: 'Maximum Visibility' },
-		{ value: 'winddirection_10m_dominant', label: 'Dominant Wind Direction (10m)' },
+		{ value: 'wind_direction_10m_dominant', label: 'Dominant Wind Direction (10m)' },
 		{ value: 'wind_gusts_10m_mean', label: 'Mean Wind Gusts (10 m)' },
 		{ value: 'wind_speed_10m_mean', label: 'Mean Wind Speed (10 m)' },
 		{ value: 'wind_gusts_10m_min', label: 'Minimum Wind Gusts (10 m)' },

--- a/src/routes/en/features/+page.svelte
+++ b/src/routes/en/features/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Button from '$lib/components/ui/button/button.svelte';
+	import { Button } from '$lib/components/ui/button';
 </script>
 
 <svelte:head>


### PR DESCRIPTION
Four bugs found while going through the codebase:

- winddirection_10m_dominant → wind_direction_10m_dominant - ~~missing underscore meant the API never picked up this parameter~~ was working fine with `winddirection_` as well

- name="cell_selection" on 15-minutely selects - copy-paste error, both forecast_minutely_15 and past_minutely_15 dropdowns were sending the wrong field name

- ~~Hash migration never ran on initial load - the old #latitude=52.52&... URL migration was in beforeNavigate, which doesn't fire on first page visit. Moved to onMount so old bookmarks actually get migrated~~ moved to #1048 

- Array vs string comparison in url-hash-store.ts - searchParams.get(key) returns a string, the code was comparing it against an array. Always true, causing pointless delete-then-set cycles. Used join(',') for a proper comparison
Also swept up a few minor things: trailing space in a label, commented-out line in +layout.ts, emoji repetition in the landing page meta desc, and normalized a batch of UI component imports that mixed barrel and direct .svelte paths.