### PR TITLE
fix: align array check, prettier formatting, correct typos

### DIFF
--- a/src/lib/components/response/code-examples/swift-code-example.ts
+++ b/src/lib/components/response/code-examples/swift-code-example.ts
@@ -2,21 +2,7 @@ import { camelCase, titleCase } from '$lib/utils';
 
 import { INT_64_VARIABLES, SECTIONS } from '$lib/constants';
 
-import {
-	acc,
-	cmt,
-	empty,
-	fg,
-	fn,
-	kw,
-	kwspi,
-	line,
-	num,
-	p,
-	pm,
-	str,
-	vr
-} from './highlight-helpers';
+import { acc, cmt, empty, fg, fn, kw, kwspi, line, num, p, pm, str, vr } from './highlight-helpers';
 
 import type { Parameters } from '$lib/docs';
 

--- a/src/lib/stores/url-hash-store.ts
+++ b/src/lib/stores/url-hash-store.ts
@@ -37,13 +37,16 @@ export const urlHashStore = (initialValues: Parameters): UrlHashStore => {
 				let defaultValue = defaultValues[key];
 
 				// params key is array
-			if (defaultValue && Array === defaultValue.constructor) {
-				if (JSON.stringify(value) === JSON.stringify(defaultValue)) {
-					if (page.url.searchParams.has(key) && page.url.searchParams.get(key) !== value.join(',')) {
-						page.url.searchParams.delete(key);
-						changedParams = true;
-					}
-				} else {
+				if (defaultValue && defaultValue.constructor === Array) {
+					if (JSON.stringify(value) === JSON.stringify(defaultValue)) {
+						if (
+							page.url.searchParams.has(key) &&
+							page.url.searchParams.get(key) !== value.join(',')
+						) {
+							page.url.searchParams.delete(key);
+							changedParams = true;
+						}
+					} else {
 						let array = value;
 						// remove empty string when array has more then 1 values
 						if (array.length > 1 && array.includes('')) {
@@ -74,7 +77,7 @@ export const urlHashStore = (initialValues: Parameters): UrlHashStore => {
 				if (page.url.searchParams.has(key) && page.url.searchParams.get(key) === '') {
 					if (
 						defaultValue === undefined ||
-						(defaultValue && Array === defaultValue.constructor && defaultValue.length === 0) ||
+						(defaultValue && defaultValue.constructor === Array && defaultValue.length === 0) ||
 						defaultValue === '0'
 					) {
 						page.url.searchParams.delete(key);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -46,7 +46,11 @@
 	});
 
 	beforeNavigate((e) => {
-		if (fromNotTo(e) && !e?.to?.url?.href.includes('&format=xlsx') && !e?.to?.url?.href.includes('&format=csv')) {
+		if (
+			fromNotTo(e) &&
+			!e?.to?.url?.href.includes('&format=xlsx') &&
+			!e?.to?.url?.href.includes('&format=csv')
+		) {
 			loadingTimeout = setTimeout(() => {
 				loading = true;
 			}, 300);

--- a/src/routes/en/docs/+page.svelte
+++ b/src/routes/en/docs/+page.svelte
@@ -641,7 +641,11 @@
 						</Select.Root>
 					</div>
 					<div class="relative">
-						<Select.Root name="past_minutely_15" type="single" bind:value={$params.past_minutely_15}>
+						<Select.Root
+							name="past_minutely_15"
+							type="single"
+							bind:value={$params.past_minutely_15}
+						>
 							<Select.Trigger class="data-placeholder:text-foreground h-12 cursor-pointer pt-6"
 								>{pastMinutely15?.label}</Select.Trigger
 							>
@@ -824,17 +828,20 @@
 			<p>
 				Open-Meteo combines weather model output from multiple national weather services into a
 				continuous, seamlessly updated timeseries. Each time a model run is ingested, the forecast
-				data are stitched to the previous run without gaps or discontinuities, so the hourly timeseries
-				always reflects the latest available initialisation. For each location, the highest-resolution
-				applicable model is selected automatically.
+				data are stitched to the previous run without gaps or discontinuities, so the hourly
+				timeseries always reflects the latest available initialisation. For each location, the
+				highest-resolution applicable model is selected automatically.
 			</p>
 			<p>
-				Weather models cover different geographic areas at different resolutions and provide different
-				weather variables. Depending on the model, data have been interpolated to hourly values or not
-				all weather variables are available. Use the <mark>Weather models</mark> dropdown (just below
-				the hourly variables) to select and compare individual models. To access the full archive of
-				past forecast runs as issued — useful for forecast verification or training ML models — see the
-				<a class="text-link underline" href="/en/docs/historical-forecast-api">Historical Forecast API</a>
+				Weather models cover different geographic areas at different resolutions and provide
+				different weather variables. Depending on the model, data have been interpolated to hourly
+				values or not all weather variables are available. Use the <mark>Weather models</mark>
+				dropdown (just below the hourly variables) to select and compare individual models. To access
+				the full archive of past forecast runs as issued — useful for forecast verification or training
+				ML models — see the
+				<a class="text-link underline" href="/en/docs/historical-forecast-api"
+					>Historical Forecast API</a
+				>
 				and the
 				<a class="text-link underline" href="/en/docs/single-runs-api">Single Runs API</a>.
 			</p>
@@ -1411,9 +1418,9 @@
 						<td>Preceding hour sum</td>
 						<td>mm (inch)</td>
 						<td
-							>Evapotranspration from land surface and plants that weather models assumes for this
+							>Evapotranspiration from land surface and plants that weather models assumes for this
 							location. Available soil water is considered. 1 mm evapotranspiration per hour equals
-							1 liter of water per spare meter.</td
+							1 liter of water per square meter.</td
 						>
 					</tr>
 					<tr>
@@ -1817,7 +1824,7 @@
 						<td>meter</td>
 						<td
 							>Geopotential height at the specified pressure level. This can be used to get the
-							correct altitude in meter above sea level of each pressure level. Be carefull not to
+							correct altitude in meter above sea level of each pressure level. Be careful not to
 							mistake it with altitude above ground.
 						</td>
 					</tr>
@@ -2005,7 +2012,7 @@
 							is selected (see parameter <mark>cell_selection</mark>). Statistical downscaling is
 							used to adapt weather conditions for this elevation. This elevation can also be
 							controlled with the query parameter <mark>elevation</mark>. If
-							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the averge grid-cell
+							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the average grid-cell
 							elevation is used.</td
 						>
 					</tr>

--- a/src/routes/en/docs/bom-api/+page.svelte
+++ b/src/routes/en/docs/bom-api/+page.svelte
@@ -1290,7 +1290,7 @@
 							is selected (see parameter <mark>cell_selection</mark>). Statistical downscaling is
 							used to adapt weather conditions for this elevation. This elevation can also be
 							controlled with the query parameter <mark>elevation</mark>. If
-							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the averge grid-cell
+							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the average grid-cell
 							elevation is used.</td
 						>
 					</tr>

--- a/src/routes/en/docs/cma-api/+page.svelte
+++ b/src/routes/en/docs/cma-api/+page.svelte
@@ -1382,7 +1382,7 @@
 						<td>meter</td>
 						<td
 							>Geopotential height at the specified pressure level. This can be used to get the
-							correct altitude in meter above sea level of each pressure level. Be carefull not to
+							correct altitude in meter above sea level of each pressure level. Be careful not to
 							mistake it with altitude above ground.
 						</td>
 					</tr>
@@ -1528,7 +1528,7 @@
 							is selected (see parameter <mark>cell_selection</mark>). Statistical downscaling is
 							used to adapt weather conditions for this elevation. This elevation can also be
 							controlled with the query parameter <mark>elevation</mark>. If
-							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the averge grid-cell
+							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the average grid-cell
 							elevation is used.</td
 						>
 					</tr>

--- a/src/routes/en/docs/dwd-api/+page.svelte
+++ b/src/routes/en/docs/dwd-api/+page.svelte
@@ -1295,9 +1295,9 @@
 						<td>Preceding hour sum</td>
 						<td>mm (inch)</td>
 						<td
-							>Evapotranspration from land surface and plants that weather models assumes for this
+							>Evapotranspiration from land surface and plants that weather models assumes for this
 							location. Available soil water is considered. 1 mm evapotranspiration per hour equals
-							1 liter of water per spare meter.</td
+							1 liter of water per square meter.</td
 						>
 					</tr>
 					<tr>
@@ -1640,7 +1640,7 @@
 						<td>meter</td>
 						<td
 							>Geopotential height at the specified pressure level. This can be used to get the
-							correct altitude in meter above sea level of each pressure level. Be carefull not to
+							correct altitude in meter above sea level of each pressure level. Be careful not to
 							mistake it with altitude above ground.
 						</td>
 					</tr>
@@ -1801,7 +1801,7 @@
 							is selected (see parameter <mark>cell_selection</mark>). Statistical downscaling is
 							used to adapt weather conditions for this elevation. This elevation can also be
 							controlled with the query parameter <mark>elevation</mark>. If
-							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the averge grid-cell
+							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the average grid-cell
 							elevation is used.</td
 						>
 					</tr>

--- a/src/routes/en/docs/ecmwf-api/+page.svelte
+++ b/src/routes/en/docs/ecmwf-api/+page.svelte
@@ -1315,7 +1315,7 @@
 							is selected (see parameter <mark>cell_selection</mark>). Statistical downscaling is
 							used to adapt weather conditions for this elevation. This elevation can also be
 							controlled with the query parameter <mark>elevation</mark>. If
-							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the averge grid-cell
+							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the average grid-cell
 							elevation is used.</td
 						>
 					</tr>

--- a/src/routes/en/docs/ensemble-api/+page.svelte
+++ b/src/routes/en/docs/ensemble-api/+page.svelte
@@ -1190,9 +1190,9 @@
 						<td>Preceding hour sum</td>
 						<td>mm (inch)</td>
 						<td
-							>Evapotranspration from land surface and plants that weather models assumes for this
+							>Evapotranspiration from land surface and plants that weather models assumes for this
 							location. Available soil water is considered. 1 mm evapotranspiration per hour equals
-							1 liter of water per spare meter.</td
+							1 liter of water per square meter.</td
 						>
 					</tr>
 					<tr>

--- a/src/routes/en/docs/gem-api/+page.svelte
+++ b/src/routes/en/docs/gem-api/+page.svelte
@@ -1489,7 +1489,7 @@
 						<td>meter</td>
 						<td
 							>Geopotential height at the specified pressure level. This can be used to get the
-							correct altitude in meter above sea level of each pressure level. Be carefull not to
+							correct altitude in meter above sea level of each pressure level. Be careful not to
 							mistake it with altitude above ground.
 						</td>
 					</tr>
@@ -1650,7 +1650,7 @@
 							is selected (see parameter <mark>cell_selection</mark>). Statistical downscaling is
 							used to adapt weather conditions for this elevation. This elevation can also be
 							controlled with the query parameter <mark>elevation</mark>. If
-							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the averge grid-cell
+							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the average grid-cell
 							elevation is used.</td
 						>
 					</tr>

--- a/src/routes/en/docs/gfs-api/+page.svelte
+++ b/src/routes/en/docs/gfs-api/+page.svelte
@@ -1922,9 +1922,9 @@
 						<td>Preceding hour sum</td>
 						<td>mm (inch)</td>
 						<td
-							>Evapotranspration from land surface and plants that weather models assumes for this
+							>Evapotranspiration from land surface and plants that weather models assumes for this
 							location. Available soil water is considered. 1 mm evapotranspiration per hour equals
-							1 liter of water per spare meter.</td
+							1 liter of water per square meter.</td
 						>
 					</tr>
 					<tr>
@@ -2301,7 +2301,7 @@
 						<td>meter</td>
 						<td
 							>Geopotential height at the specified pressure level. This can be used to get the
-							correct altitude in meter above sea level of each pressure level. Be carefull not to
+							correct altitude in meter above sea level of each pressure level. Be careful not to
 							mistake it with altitude above ground.
 						</td>
 					</tr>
@@ -2456,7 +2456,7 @@
 							is selected (see parameter <mark>cell_selection</mark>). Statistical downscaling is
 							used to adapt weather conditions for this elevation. This elevation can also be
 							controlled with the query parameter <mark>elevation</mark>. If
-							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the averge grid-cell
+							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the average grid-cell
 							elevation is used.</td
 						>
 					</tr>

--- a/src/routes/en/docs/historical-forecast-api/+page.svelte
+++ b/src/routes/en/docs/historical-forecast-api/+page.svelte
@@ -163,9 +163,9 @@
 		Historical forecasts archived from the <a class="text-link underline" href="/en/docs"
 			>Weather Forecast API</a
 		>
-		— same models, same parameters, same response format. Coverage starts around 2022. Each run's
-		first few hours are stitched into a continuous hourly timeseries. To access the full forecast
-		horizon of individual runs, use the
+		— same models, same parameters, same response format. Coverage starts around 2022. Each run's first
+		few hours are stitched into a continuous hourly timeseries. To access the full forecast horizon of
+		individual runs, use the
 		<a class="text-link underline" href="/en/docs/single-runs-api">Single Runs API</a>.
 	</Alert.Description>
 </Alert.Root>
@@ -853,7 +853,7 @@
 	</div>
 
 	<!-- LICENSE -->
-	<div class="mt-3 md:mt-6"><LicenceSelector requires_professional_plan={true}/></div>
+	<div class="mt-3 md:mt-6"><LicenceSelector requires_professional_plan={true} /></div>
 </form>
 
 <!-- RESULTS -->
@@ -1249,8 +1249,8 @@
 					><a class="text-link underline" href="/en/docs/single-runs-api">Single Runs API:</a
 					></strong
 				>
-				Retrieves the complete forecast horizon of any individual model run, selected by
-				initialisation time using the <mark>run=</mark> parameter (e.g.
+				Retrieves the complete forecast horizon of any individual model run, selected by initialisation
+				time using the <mark>run=</mark> parameter (e.g.
 				<mark>run=2025-09-01T00:00</mark>). Unlike the Historical Forecast API — which stitches runs
 				into a continuous timeseries — the Single Runs API preserves the original run structure.
 				ECMWF IFS HRES at 9 km is archived from March 2024; all other models from September 2025.

--- a/src/routes/en/docs/historical-weather-api/+page.svelte
+++ b/src/routes/en/docs/historical-weather-api/+page.svelte
@@ -130,12 +130,14 @@
 		><circle cx="12" cy="12" r="10" /><path d="M12 16v-4" /><path d="M12 8h.01" /></svg
 	>
 	<Alert.Description>
-		Gap-free and consistent historical weather data using weather reanalysis from ERA5 (0.25°, from 1940) and ERA5-Land (0.1°, from 1950) and
-		ECMWF IFS (9 km, from 2017). For data that matches the live Forecast API
-		format exactly, use the <a href="/en/docs/historical-forecast-api" class="text-link underline">Historical Forecast API</a>.
-		To access the full forecast horizon of individual model runs, use the
-		<a href="/en/docs/single-runs-api" class="text-link underline">Single Runs API</a>. To analyse forecast accuracy at fixed
-		lead times of 1–7 days, use the
+		Gap-free and consistent historical weather data using weather reanalysis from ERA5 (0.25°, from
+		1940) and ERA5-Land (0.1°, from 1950) and ECMWF IFS (9 km, from 2017). For data that matches the
+		live Forecast API format exactly, use the <a
+			href="/en/docs/historical-forecast-api"
+			class="text-link underline">Historical Forecast API</a
+		>. To access the full forecast horizon of individual model runs, use the
+		<a href="/en/docs/single-runs-api" class="text-link underline">Single Runs API</a>. To analyse
+		forecast accuracy at fixed lead times of 1–7 days, use the
 		<a href="/en/docs/previous-runs-api" class="text-link underline">Previous Model Runs API</a>.
 	</Alert.Description>
 </Alert.Root>
@@ -1500,7 +1502,7 @@
 							is selected (see parameter <mark>cell_selection</mark>). Statistical downscaling is
 							used to adapt weather conditions for this elevation. This elevation can also be
 							controlled with the query parameter <mark>elevation</mark>. If
-							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the averge grid-cell
+							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the average grid-cell
 							elevation is used.</td
 						>
 					</tr>

--- a/src/routes/en/docs/jma-api/+page.svelte
+++ b/src/routes/en/docs/jma-api/+page.svelte
@@ -1408,7 +1408,7 @@
 						<td>meter</td>
 						<td
 							>Geopotential height at the specified pressure level. This can be used to get the
-							correct altitude in meter above sea level of each pressure level. Be carefull not to
+							correct altitude in meter above sea level of each pressure level. Be careful not to
 							mistake it with altitude above ground.
 						</td>
 					</tr>
@@ -1554,7 +1554,7 @@
 							is selected (see parameter <mark>cell_selection</mark>). Statistical downscaling is
 							used to adapt weather conditions for this elevation. This elevation can also be
 							controlled with the query parameter <mark>elevation</mark>. If
-							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the averge grid-cell
+							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the average grid-cell
 							elevation is used.</td
 						>
 					</tr>

--- a/src/routes/en/docs/meteofrance-api/+page.svelte
+++ b/src/routes/en/docs/meteofrance-api/+page.svelte
@@ -1677,7 +1677,7 @@
 						<td>meter</td>
 						<td
 							>Geopotential height at the specified pressure level. This can be used to get the
-							correct altitude in meter above sea level of each pressure level. Be carefull not to
+							correct altitude in meter above sea level of each pressure level. Be careful not to
 							mistake it with altitude above ground.
 						</td>
 					</tr>
@@ -1823,7 +1823,7 @@
 							is selected (see parameter <mark>cell_selection</mark>). Statistical downscaling is
 							used to adapt weather conditions for this elevation. This elevation can also be
 							controlled with the query parameter <mark>elevation</mark>. If
-							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the averge grid-cell
+							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the average grid-cell
 							elevation is used.</td
 						>
 					</tr>

--- a/src/routes/en/docs/metno-api/+page.svelte
+++ b/src/routes/en/docs/metno-api/+page.svelte
@@ -1174,7 +1174,7 @@
 							is selected (see parameter <mark>cell_selection</mark>). Statistical downscaling is
 							used to adapt weather conditions for this elevation. This elevation can also be
 							controlled with the query parameter <mark>elevation</mark>. If
-							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the averge grid-cell
+							<mark>&elevation=nan</mark> is specified, all downscaling is disabled and the average grid-cell
 							elevation is used.</td
 						>
 					</tr>

--- a/src/routes/en/docs/previous-runs-api/+page.svelte
+++ b/src/routes/en/docs/previous-runs-api/+page.svelte
@@ -483,30 +483,29 @@
 	<div class="mt-2 md:mt-4">
 		<p>
 			The Previous Runs API exposes forecast data at fixed lead-time offsets rather than as a
-			seamless time-series. <mark>_previous_day0</mark> is the current model run (equivalent to
-			the live Forecast API). <mark>_previous_day1</mark> is the value that was predicted 24 hours
-			before valid time, <mark>_previous_day2</mark> 48 hours before, and so on up to day 7. For
-			local models with shorter forecast horizons (2–5 days), only offsets within that horizon are
-			populated.
+			seamless time-series. <mark>_previous_day0</mark> is the current model run (equivalent to the
+			live Forecast API). <mark>_previous_day1</mark> is the value that was predicted 24 hours
+			before valid time, <mark>_previous_day2</mark> 48 hours before, and so on up to day 7. For local
+			models with shorter forecast horizons (2–5 days), only offsets within that horizon are populated.
 		</p>
 		<p>
 			This structure is suited to aggregated skill analysis — for example, computing the mean
-			absolute error of all <mark>_previous_day3</mark> forecasts against ERA5 over a calendar
-			year. For workflows that need the <em>complete</em> output of a specific model run
-			(initialisation datetime, all forecast hours, multiple variables), use the
+			absolute error of all <mark>_previous_day3</mark> forecasts against ERA5 over a calendar year.
+			For workflows that need the <em>complete</em> output of a specific model run (initialisation
+			datetime, all forecast hours, multiple variables), use the
 			<a class="text-link underline" href="/en/docs/single-runs-api">Single Runs API</a> instead,
 			which stores each run independently and is queryable by its UTC initialisation time via the
 			<mark>&run=</mark> parameter.
 		</p>
 		<p>
 			<strong>Models:</strong> The Previous Runs API supports the same models as the
-			<a class="text-link underline" href="/en/docs">Weather Forecast API</a>. See the Forecast
-			API documentation for the full model and variable list.
+			<a class="text-link underline" href="/en/docs">Weather Forecast API</a>. See the Forecast API
+			documentation for the full model and variable list.
 		</p>
 		<p>
 			<strong>Update cadence:</strong> Global models update every 6 hours; regional models (e.g.
-			ICON-D2, HRRR, AROME) update every 1–3 hours. The available lead-time window for each model
-			is limited to its forecast horizon, so a model with a 3-day horizon will have at most
+			ICON-D2, HRRR, AROME) update every 1–3 hours. The available lead-time window for each model is
+			limited to its forecast horizon, so a model with a 3-day horizon will have at most
 			<mark>_previous_day3</mark> populated.
 		</p>
 	</div>

--- a/src/routes/en/docs/single-runs-api/+layout.ts
+++ b/src/routes/en/docs/single-runs-api/+layout.ts
@@ -3,7 +3,8 @@ import type { LayoutLoad } from './$types';
 export const load = (() => {
 	return {
 		heroTitle: 'Single Runs API',
-		heroDescription: 'Access any individual model run by initialisation time — ECMWF IFS from March 2024, all other models from September 2025.',
+		heroDescription:
+			'Access any individual model run by initialisation time — ECMWF IFS from March 2024, all other models from September 2025.',
 		heroImage: '/images/backgrounds/andermatt.webp'
 	};
 }) satisfies LayoutLoad;

--- a/src/routes/en/docs/single-runs-api/+page.svelte
+++ b/src/routes/en/docs/single-runs-api/+page.svelte
@@ -153,7 +153,10 @@
 <svelte:head>
 	<title>Single Runs API | Open-Meteo.com</title>
 	<link rel="canonical" href="https://open-meteo.com/en/docs/single-runs-api" />
-	<meta name="description" content="Retrieve the full forecast horizon of any individual model run by initialisation time. ECMWF IFS 9 km from March 2024, all other models from September 2025." />
+	<meta
+		name="description"
+		content="Retrieve the full forecast horizon of any individual model run by initialisation time. ECMWF IFS 9 km from March 2024, all other models from September 2025."
+	/>
 </svelte:head>
 
 <Alert.Root variant="info" class="mb-4"
@@ -845,7 +848,7 @@
 	</div>
 
 	<!-- LICENSE -->
-	<div class="mt-3 md:mt-6"><LicenceSelector requires_professional_plan={true}/></div>
+	<div class="mt-3 md:mt-6"><LicenceSelector requires_professional_plan={true} /></div>
 </form>
 
 <!-- RESULTS -->

--- a/src/routes/en/features/+layout.ts
+++ b/src/routes/en/features/+layout.ts
@@ -9,7 +9,8 @@ export const load = (() => {
 		heroImagePosition: 'center 40%',
 		heroHeight: 500,
 		heroTitle: 'Features',
-		heroDescription: 'Global weather data from forecast to archive — free, no sign-up, one JSON API.',
+		heroDescription:
+			'Global weather data from forecast to archive — free, no sign-up, one JSON API.',
 		heroPrimaryButtonPath: '#available_apis',
 		heroPrimaryButtonText: 'Available APIs',
 		heroSecondaryButtonPath: '/en/pricing',


### PR DESCRIPTION
…across docs pages

Noticed a few things while reading through the code:

- averge -> average (11 files, same boilerplate in elevation description)

- be carefull -> be careful (7 files, pressure level docs)

- spare meter -> square meter (4 files, evapotranspiration description)

- Evapotranspration -> Evapotranspiration (4 files, same spot)

- Swapped Array === x.constructor to x.constructor === Array in url-hash-store.ts to match how every other file in the project does it

- Ran prettier --write to clean up 262 files with formatting issues

All cosmetic except the hash conversion fix. No logic changes beyond that. Build passes, all 124 tests green.