### PR TITLE
fix: canonical URLs on error/404 pages pointing to wrong path

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -189,17 +189,15 @@
 	--color-accent: var(--accent);
 	--color-accent-foreground: var(--accent-foreground);
 	--color-destructive: var(--destructive);
+	--color-destructive-foreground: var(--destructive-foreground);
 	--color-border: var(--border);
+	--color-border-dark: var(--border-dark);
 	--color-input: var(--input);
 	--color-ring: var(--ring);
 	--color-link: var(--link);
-	--color-border: var(--border);
-	--color-border-dark: var(--border-dark);
 	--color-warning: var(--warning);
 	--color-warning-dark: var(--warning-dark);
 	--color-warning-foreground: var(--warning-foreground);
-	--color-destructive: var(--destructive);
-	--color-destructive-foreground: var(--destructive-foreground);
 	--color-mark-color: var(--mark-color);
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -189,15 +189,17 @@
 	--color-accent: var(--accent);
 	--color-accent-foreground: var(--accent-foreground);
 	--color-destructive: var(--destructive);
-	--color-destructive-foreground: var(--destructive-foreground);
 	--color-border: var(--border);
-	--color-border-dark: var(--border-dark);
 	--color-input: var(--input);
 	--color-ring: var(--ring);
 	--color-link: var(--link);
+	--color-border: var(--border);
+	--color-border-dark: var(--border-dark);
 	--color-warning: var(--warning);
 	--color-warning-dark: var(--warning-dark);
 	--color-warning-foreground: var(--warning-foreground);
+	--color-destructive: var(--destructive);
+	--color-destructive-foreground: var(--destructive-foreground);
 	--color-mark-color: var(--mark-color);
 }
 

--- a/src/lib/components/response/results-preview.svelte
+++ b/src/lib/components/response/results-preview.svelte
@@ -234,7 +234,7 @@
 
 			/// Number of locations
 			let nLocations = 1;
-			if (cwParams['latitude'] && Array == cwParams['latitude'].constructor) {
+			if (cwParams['latitude'] && Array.isArray(cwParams['latitude'])) {
 				nLocations = cwParams['latitude']?.length ?? 1;
 			}
 			/// Calculate adjusted weight

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -10,7 +10,7 @@
 
 <svelte:head>
 	<title>500 Error | Open-Meteo.com</title>
-	<link rel="canonical" href="https://open-meteo.com/en/about" />
+	<link rel="canonical" href="https://open-meteo.com/" />
 </svelte:head>
 
 <div class="h-[500px]">

--- a/src/routes/404/+page.svelte
+++ b/src/routes/404/+page.svelte
@@ -1,4 +1,4 @@
 <svelte:head>
 	<title>404 Error | Open-Meteo.com</title>
-	<link rel="canonical" href="https://open-meteo.com/en/about" />
+	<link rel="canonical" href="https://open-meteo.com/" />
 </svelte:head>


### PR DESCRIPTION
Found that both +error.svelte and 404/+page.svelte had the canonical URL set to https://open-meteo.com/en/about. Since these pages aren't the about page, moved them to root https://open-meteo.com/ which is more appropriate for error/404 responses.

Also deduplicated two CSS custom properties in app.css (--color-destructive and --color-border) and replaced a loose Array == constructor check with Array.isArray(). No functional changes.