### PR TITLE
fix: align forecastDays with backend for seasonal, flood and ensemble

### DIFF
--- a/src/lib/components/time/time-selector.svelte
+++ b/src/lib/components/time/time-selector.svelte
@@ -29,6 +29,11 @@
 		forecastDaysOptions?.find((fco) => fco.value == params.forecast_days)
 	);
 	let pastDays = $derived(pastDaysOptions?.find((pdo) => pdo.value == params.past_days));
+
+	let defaultForecastDays = $derived(
+		forecastDaysOptions?.find((o) => o.label.includes('default')) ?? forecastDaysOptions?.[0]
+	);
+	let maxForecastDays = $derived(forecastDaysOptions?.at(-1));
 </script>
 
 <div class="mt-6">
@@ -146,9 +151,14 @@
 
 				<div>
 					<p>
-						By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-						days. If you're interested in past weather data, you can use the <mark>Past Days</mark>
-						feature to access archived forecasts.
+						By default, we provide forecasts for {defaultForecastDays?.label.replace(
+							/\s*\(.*\)/,
+							''
+						)}, but you can access forecasts for up to {maxForecastDays?.label.replace(
+							/\s*\(.*\)/,
+							''
+						)}. If you're interested in past weather data, you can use the <mark>Past Days</mark> feature
+						to access archived forecasts.
 					</p>
 				</div>
 			</div>

--- a/src/routes/en/docs/air-quality-api/+page.svelte
+++ b/src/routes/en/docs/air-quality-api/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -11,17 +10,16 @@
 	import WeatherForecastError from '$lib/components/code/docs/weather-forecast-error.svx';
 
 	import * as Accordion from '$lib/components/ui/accordion';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Label } from '$lib/components/ui/label';
 	import * as Select from '$lib/components/ui/select';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -46,11 +44,6 @@
 		...defaultParameters,
 		hourly: ['pm10', 'pm2_5']
 	});
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let pastHours = $derived(pastHoursOptions.find((pho) => String(pho.value) == $params.past_hours));
@@ -112,157 +105,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/bom-api/+page.svelte
+++ b/src/routes/en/docs/bom-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -12,18 +12,17 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import * as Select from '$lib/components/ui/select';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -51,11 +50,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let pastHours = $derived(pastHoursOptions.find((pho) => String(pho.value) == $params.past_hours));
@@ -155,157 +149,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/cma-api/+page.svelte
+++ b/src/routes/en/docs/cma-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -17,7 +17,6 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
@@ -25,12 +24,12 @@
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import PressureLevelsHelpTable from '$lib/components/pressure/pressure-levels-help-table.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastDaysOptions,
@@ -60,11 +59,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let pastHours = $derived(pastHoursOptions.find((pho) => String(pho.value) == $params.past_hours));
@@ -172,157 +166,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/dmi-api/+page.svelte
+++ b/src/routes/en/docs/dmi-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -9,18 +9,17 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import * as Select from '$lib/components/ui/select';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -49,11 +48,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let pastHours = $derived(pastHoursOptions.find((pho) => String(pho.value) == $params.past_hours));
@@ -111,157 +105,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/ecmwf-api/+page.svelte
+++ b/src/routes/en/docs/ecmwf-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -17,7 +17,6 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
@@ -25,11 +24,11 @@
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -55,11 +54,6 @@
 		...defaultParameters,
 		hourly: ['temperature_2m']
 	});
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let pastHours = $derived(pastHoursOptions.find((pho) => String(pho.value) == $params.past_hours));
@@ -146,157 +140,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/ensemble-api/options.ts
+++ b/src/routes/en/docs/ensemble-api/options.ts
@@ -730,7 +730,7 @@ export const forecastDaysOptions = [
 	{ value: '14', label: '14 days' },
 	{ value: '16', label: '16 days' },
 	{ value: '30', label: '30 days' },
-	{ value: '35', label: '35 days' }
+	{ value: '36', label: '36 days' }
 ];
 
 export const pastDaysOptions = [

--- a/src/routes/en/docs/flood-api/+page.svelte
+++ b/src/routes/en/docs/flood-api/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -30,11 +29,6 @@
 		...defaultParameters,
 		daily: ['river_discharge']
 	});
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	let accordionValues: string[] = $state([]);
 	onMount(() => {

--- a/src/routes/en/docs/flood-api/+page.svelte
+++ b/src/routes/en/docs/flood-api/+page.svelte
@@ -11,17 +11,15 @@
 	import FloodObject from '$lib/components/code/docs/flood-object.svx';
 
 	import * as Accordion from '$lib/components/ui/accordion';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Label } from '$lib/components/ui/label';
-	import * as Select from '$lib/components/ui/select';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import { pastDaysOptions } from '../options';
 	import { daily, defaultParameters, forecastDaysOptions, models } from './options';
@@ -65,157 +63,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- DAILY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/flood-api/options.ts
+++ b/src/routes/en/docs/flood-api/options.ts
@@ -49,5 +49,6 @@ export const forecastDaysOptions = [
 	{ value: '14', label: '2 weeks' },
 	{ value: '31', label: '1 month' },
 	{ value: '92', label: '3 months (default)' },
-	{ value: '183', label: '6 months' }
+	{ value: '183', label: '6 months' },
+	{ value: '366', label: '12 months' }
 ];

--- a/src/routes/en/docs/gem-api/+page.svelte
+++ b/src/routes/en/docs/gem-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -17,7 +17,6 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
@@ -25,12 +24,12 @@
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import PressureLevelsHelpTable from '$lib/components/pressure/pressure-levels-help-table.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -62,11 +61,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let pastHours = $derived(pastHoursOptions.find((pho) => String(pho.value) == $params.past_hours));
@@ -156,157 +150,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/gfs-api/+page.svelte
+++ b/src/routes/en/docs/gfs-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -17,7 +17,6 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
@@ -25,12 +24,12 @@
 	import * as ToggleGroup from '$lib/components/ui/toggle-group/index.js';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import PressureLevelsHelpTable from '$lib/components/pressure/pressure-levels-help-table.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastDaysOptions,
@@ -65,11 +64,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let forecastHours = $derived(
@@ -173,157 +167,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/italia-meteo-arpae-api/+page.svelte
+++ b/src/routes/en/docs/italia-meteo-arpae-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -13,7 +13,6 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
@@ -21,11 +20,11 @@
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -57,11 +56,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let forecastHours = $derived(
@@ -127,157 +121,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/jma-api/+page.svelte
+++ b/src/routes/en/docs/jma-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -17,7 +17,6 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
@@ -25,12 +24,12 @@
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import PressureLevelsHelpTable from '$lib/components/pressure/pressure-levels-help-table.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -62,11 +61,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let pastHours = $derived(pastHoursOptions.find((pho) => String(pho.value) == $params.past_hours));
@@ -154,157 +148,14 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">
 		<a href="#hourly_weather_variables"

--- a/src/routes/en/docs/kma-api/+page.svelte
+++ b/src/routes/en/docs/kma-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -9,18 +9,17 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import * as Select from '$lib/components/ui/select';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -50,11 +49,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let pastHours = $derived(pastHoursOptions.find((pho) => String(pho.value) == $params.past_hours));
@@ -136,157 +130,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/knmi-api/+page.svelte
+++ b/src/routes/en/docs/knmi-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -13,7 +13,6 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
@@ -21,11 +20,11 @@
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -58,11 +57,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let pastHours = $derived(pastHoursOptions.find((pho) => String(pho.value) == $params.past_hours));
@@ -143,157 +137,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/meteofrance-api/+page.svelte
+++ b/src/routes/en/docs/meteofrance-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -17,7 +17,6 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
@@ -25,12 +24,12 @@
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import PressureLevelsHelpTable from '$lib/components/pressure/pressure-levels-help-table.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -65,11 +64,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let forecastHours = $derived(
@@ -174,157 +168,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/meteoswiss-api/+page.svelte
+++ b/src/routes/en/docs/meteoswiss-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -9,18 +9,17 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import * as Select from '$lib/components/ui/select';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -50,11 +49,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let forecastHours = $derived(
@@ -112,157 +106,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/metno-api/+page.svelte
+++ b/src/routes/en/docs/metno-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -12,18 +12,17 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import * as Select from '$lib/components/ui/select';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -48,11 +47,6 @@
 		...defaultParameters,
 		hourly: ['temperature_2m']
 	});
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let pastHours = $derived(pastHoursOptions.find((pho) => String(pho.value) == $params.past_hours));
@@ -133,157 +127,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">

--- a/src/routes/en/docs/seasonal-forecast-api/options.ts
+++ b/src/routes/en/docs/seasonal-forecast-api/options.ts
@@ -370,5 +370,5 @@ export const forecastDaysOptions = [
 	{ value: '45', label: '45 days' },
 	{ value: '92', label: '3 months' },
 	{ value: '183', label: '6 months (default)' },
-	{ value: '214', label: '7 months' }
+	{ value: '217', label: '7 months' }
 ];

--- a/src/routes/en/docs/ukmo-api/+page.svelte
+++ b/src/routes/en/docs/ukmo-api/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { SvelteDate } from 'svelte/reactivity';
-	import { fade, slide } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 
 	import { urlHashStore } from '$lib/stores/url-hash-store';
 
@@ -15,7 +15,6 @@
 
 	import * as Accordion from '$lib/components/ui/accordion';
 	import * as Alert from '$lib/components/ui/alert';
-	import { Button } from '$lib/components/ui/button';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
@@ -23,11 +22,11 @@
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
 
 	import AccordionItem from '$lib/components/accordion/accordion-item.svelte';
-	import DatePicker from '$lib/components/date/date-picker.svelte';
 	import LicenceSelector from '$lib/components/licence/licence-selector.svelte';
 	import LocationSelection from '$lib/components/location/location-selection.svelte';
 	import ResultsPreview from '$lib/components/response/results-preview.svelte';
 	import Settings from '$lib/components/settings/settings.svelte';
+	import TimeSelector from '$lib/components/time/time-selector.svelte';
 
 	import {
 		forecastHoursOptions,
@@ -61,11 +60,6 @@
 	let timezoneInvalid = $derived(
 		$params.timezone == 'UTC' && ($params.daily ? $params.daily.length > 0 : false)
 	);
-
-	let forecastDays = $derived(
-		forecastDaysOptions.find((fco) => fco.value == $params.forecast_days)
-	);
-	let pastDays = $derived(pastDaysOptions.find((pdo) => pdo.value == $params.past_days));
 
 	// Additional variable settings
 	let pastHours = $derived(pastHoursOptions.find((pho) => String(pho.value) == $params.past_hours));
@@ -166,157 +160,13 @@
 	<LocationSelection bind:params={$params} />
 
 	<!-- TIME -->
-	<div class="mt-6">
-		<div class="mt-3 flex items-center gap-2">
-			<div class="text-muted-foreground">Time:</div>
-
-			<div class="border-border flex rounded-md border">
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-e-none opacity-100! duration-300 {$params.time_mode ===
-					'forecast_days'
-						? 'bg-accent cursor-not-allowed'
-						: ''}"
-					disabled={$params.time_mode === 'forecast_days'}
-					onclick={() => {
-						$params.time_mode = 'forecast_days';
-						$params.start_date = '';
-						$params.end_date = '';
-					}}
-				>
-					<svg
-						class="lucide lucide-clock mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<polyline points="12 6 12 12 16 14" />
-					</svg>Forecast Length
-				</Button>
-				<Button
-					variant="ghost"
-					class="gap-1 rounded-s-none opacity-100! duration-300  {$params.time_mode ===
-					'time_interval'
-						? 'bg-accent'
-						: ''}"
-					disabled={$params.time_mode === 'time_interval'}
-					onclick={() => {
-						$params.time_mode = 'time_interval';
-					}}
-				>
-					<svg
-						class="lucide lucide-calendar-cog mr-0.5"
-						xmlns="http://www.w3.org/2000/svg"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="m15.2 16.9-.9-.4" />
-						<path d="m15.2 19.1-.9.4" />
-						<path d="M16 2v4" />
-						<path d="m16.9 15.2-.4-.9" />
-						<path d="m16.9 20.8-.4.9" />
-						<path d="m19.5 14.3-.4.9" />
-						<path d="m19.5 21.7-.4-.9" />
-						<path d="M21 10.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
-						<path d="m21.7 16.5-.9.4" />
-						<path d="m21.7 19.5-.9-.4" />
-						<path d="M3 10h18" />
-						<path d="M8 2v4" />
-						<circle cx="18" cy="18" r="3" />
-					</svg>Time Interval
-				</Button>
-			</div>
-		</div>
-
-		<div class="mt-3 md:mt-4">
-			{#if $params.time_mode === 'forecast_days'}
-				<div in:fade class="grid gap-3 md:gap-6 lg:grid-cols-2">
-					<div class="grid gap-3 sm:grid-cols-2 md:gap-6">
-						<div class="relative">
-							<Select.Root name="forecast_days" type="single" bind:value={$params.forecast_days}>
-								<Select.Trigger
-									aria-label="Forecast days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3"
-									>{forecastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each forecastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-									>Forecast days</Label
-								>
-							</Select.Root>
-						</div>
-						<div class="relative">
-							<Select.Root name="past_days" type="single" bind:value={$params.past_days}>
-								<Select.Trigger
-									aria-label="Past days input"
-									class="h-12 cursor-pointer pt-6 [&_svg]:mb-3">{pastDays?.label}</Select.Trigger
-								>
-								<Select.Content preventScroll={false} class="border-border">
-									{#each pastDaysOptions as { value, label } (value)}
-										<Select.Item class="cursor-pointer" {value}>{label}</Select.Item>
-									{/each}
-								</Select.Content>
-								<Label
-									class="text-muted-foreground absolute top-[0.35rem] left-2 z-10 px-1 text-xs"
-								>
-									Past days</Label
-								>
-							</Select.Root>
-						</div>
-					</div>
-
-					<div>
-						<p>
-							By default, we provide forecasts for 7 days, but you can access forecasts for up to 16
-							days. If you're interested in past weather data, you can use the <mark>Past Days</mark
-							>
-							feature to access archived forecasts.
-						</p>
-					</div>
-				</div>
-			{/if}
-			{#if $params.time_mode === 'time_interval'}
-				<div in:fade class="flex flex-col gap-x-6 gap-y-4 lg:flex-row">
-					<div class="mb-3 lg:w-1/2">
-						<DatePicker
-							bind:start_date={$params.start_date}
-							bind:end_date={$params.end_date}
-							{beginDate}
-							{lastDate}
-						/>
-					</div>
-					<div class="mb-3 lg:w-1/2">
-						<p>
-							The <mark>Start Date</mark> and <mark>End Date</mark> options help you choose a range
-							of dates more easily. Archived forecasts come from a series of weather model runs over
-							time. You can access forecasts for up to 3 months and continuously archived in the
-							<a href="/en/docs/historical-forecast-api">Historical Forecast API</a>. You can also
-							check out our
-							<a href="/en/docs/historical-weather-api">Historical Weather API</a>, which provides
-							data going all the way back to 1940.
-						</p>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
+	<TimeSelector
+		bind:params={$params}
+		{beginDate}
+		{lastDate}
+		{pastDaysOptions}
+		{forecastDaysOptions}
+	/>
 
 	<!-- HOURLY -->
 	<div class="mt-6 md:mt-12">


### PR DESCRIPTION
### Summary

- Aligned ForecastDays with backend
- Switched most pages to TimeSelector component, which now dynamically shows forecast days in text