### PR TITLE
fix: three bugs and fix CI dependency conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
 				"mode-watcher": "^1.1.0",
 				"openmeteo": "^1.2.0",
 				"prettier": "^3.8.0",
-				"prettier-plugin-svelte": "^4.0.1",
+				"prettier-plugin-svelte": "^3.5.2",
 				"prettier-plugin-tailwindcss": "^0.8.0",
 				"prism-themes": "^1.9.0",
 				"rollup-plugin-visualizer": "^7.0.0",
@@ -7694,17 +7694,14 @@
 			}
 		},
 		"node_modules/prettier-plugin-svelte": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.0.1.tgz",
-			"integrity": "sha512-oDVmtKi+M8bJeUoMfPvulUqZYcuXrs5AmhhLYPKtBeg6hcpMdx7UYYisVCqEaLQuKtiPSYFpotfwp4cZK3D4xw==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.2.tgz",
+			"integrity": "sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=20"
-			},
 			"peerDependencies": {
 				"prettier": "^3.0.0",
-				"svelte": "^5.0.0"
+				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
 			}
 		},
 		"node_modules/prettier-plugin-tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"mode-watcher": "^1.1.0",
 		"openmeteo": "^1.2.0",
 		"prettier": "^3.8.0",
-		"prettier-plugin-svelte": "^4.0.1",
+		"prettier-plugin-svelte": "^3.5.2",
 		"prettier-plugin-tailwindcss": "^0.8.0",
 		"prism-themes": "^1.9.0",
 		"rollup-plugin-visualizer": "^7.0.0",

--- a/src/routes/en/docs/+layout.ts
+++ b/src/routes/en/docs/+layout.ts
@@ -2,7 +2,7 @@ import Cog from '$lib/assets/icons/cog.svelte';
 
 import type { LayoutLoad } from './$types';
 
-export const load: LayoutLoad = async () => {
+export const load = (() => {
 	return {
 		Logo: Cog,
 		heroTitle: 'Weather Forecast API',
@@ -15,4 +15,4 @@ export const load: LayoutLoad = async () => {
 		heroSecondaryButtonPath: null,
 		heroSecondaryButtonText: null
 	};
-};
+}) satisfies LayoutLoad;

--- a/src/routes/en/docs/satellite-radiation-api/+layout.ts
+++ b/src/routes/en/docs/satellite-radiation-api/+layout.ts
@@ -1,6 +1,6 @@
 import type { LayoutLoad } from './$types';
 
-export const load: LayoutLoad = async () => {
+export const load = (() => {
 	return {
 		heroTitle: 'Satellite Radiation API',
 		heroDescription: 'Real-time Solar Irradiance From Multiple Satellites',
@@ -11,4 +11,4 @@ export const load: LayoutLoad = async () => {
 		heroSecondaryButtonPath: null,
 		heroSecondaryButtonText: null
 	};
-};
+}) satisfies LayoutLoad;

--- a/src/routes/en/docs/single-runs-api/options.ts
+++ b/src/routes/en/docs/single-runs-api/options.ts
@@ -163,7 +163,6 @@ export const daily = [
 export const additionalDaily = [
 	[
 		{ value: 'temperature_2m_mean', label: 'Mean Temperature (2 m)' },
-		{ value: 'temperature_2m_min', label: 'Minimum Temperature (2 m)' },
 		{ value: 'apparent_temperature_mean', label: 'Mean Apparent Temperature (2 m)' },
 		{ value: 'cape_mean', label: 'Mean CAPE' },
 		{ value: 'cape_max', label: 'Maximum CAPE' },


### PR DESCRIPTION
Looking through the code I found a few things:

1. Two layout files (en/docs/+layout.ts and satellite-radiation-api/+layout.ts) had async on the load function but never used await. Wasn't hurting anything but cleanup.

3. The single-runs-api options.ts had temperature_2m_min in both daily and additionalDaily arrays. Since both sections bind to the same $params.daily, this was showing up twice in the UI and would send duplicate params to the API. Moved it out of additionalDaily.

5. CI was failing because @trivago/prettier-plugin-sort-imports needs prettier-plugin-svelte@3.x but package.json had ^4.0.1. Downgraded to ^3.5.2 and updated lockfile.