### PR TITLE
fix: remove dead code exports, unused persisted stores, and fix broken Cypress test selector

### DIFF
--- a/src/lib/components/header/darkmode-toggle/darkmode-toggle.cy.ts
+++ b/src/lib/components/header/darkmode-toggle/darkmode-toggle.cy.ts
@@ -6,7 +6,7 @@ describe('DarkmodeToggle', () => {
 	it('should switch modes', () => {
 		cy.mount(ModeWatcher).then(() => {
 			cy.mount(DarkmodeToggle);
-			cy.get('#darkmode_toggle').click();
+			cy.get('[aria-label="Toggle theme"]').click();
 		});
 	});
 });

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,5 +1,3 @@
-import { writable } from 'svelte/store';
-
 import { persisted } from 'svelte-persisted-store';
 
 export const apiKeyPreferences = persisted('api_key_preferences', {
@@ -7,16 +5,6 @@ export const apiKeyPreferences = persisted('api_key_preferences', {
 	apikey: '',
 	self_host_server: 'https://my-server.tld'
 });
-
-export const units = persisted('units', {
-	windSpeed: 'kmh',
-	temperature: 'celsius',
-	precipitation: 'mm'
-});
-
-export const model = persisted('model', 'best_match');
-export const theme = persisted('theme', 'auto');
-export const themeIsDark = writable(true);
 
 export interface GeoLocation {
 	id: number;
@@ -39,27 +27,5 @@ export interface GeoLocation {
 	admin4?: string | undefined;
 }
 
-export const defaultLocation: GeoLocation = {
-	id: 2950159,
-	name: 'Berlin',
-	latitude: 52.52437,
-	longitude: 13.41053,
-	elevation: 74,
-	feature_code: 'PPLC',
-	country_code: 'DE',
-	admin1_id: 2950157,
-	admin3_id: 6547383,
-	admin4_id: 6547539,
-	timezone: 'Europe/Berlin',
-	population: 3426354,
-	postcodes: ['10967', '13347'],
-	country_id: 2921044,
-	country: 'Germany',
-	admin1: 'Land Berlin',
-	admin3: 'Berlin, Stadt',
-	admin4: 'Berlin'
-};
-
-export const storedLocation = persisted('stored_location', defaultLocation as GeoLocation);
 export const lastVisited = persisted('last_visited_locations', [] as GeoLocation[]);
 export const favorites = persisted('favorites', [] as GeoLocation[]);

--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test, vi } from 'vitest';
 
 import {
 	camelCase,
-	capitalizeFirstLetter,
 	debounce,
 	isAvailable,
 	isDailyAvailable,
@@ -142,28 +141,6 @@ describe('camelCase', () => {
 
 	test('leaves single word lowercase', () => {
 		expect(camelCase('hello')).toBe('hello');
-	});
-});
-
-describe('capitalizeFirstLetter', () => {
-	test('capitalizes lowercase word', () => {
-		expect(capitalizeFirstLetter('hello')).toBe('Hello');
-	});
-
-	test('keeps already capitalized word unchanged', () => {
-		expect(capitalizeFirstLetter('Hello')).toBe('Hello');
-	});
-
-	test('capitalizes single character', () => {
-		expect(capitalizeFirstLetter('a')).toBe('A');
-	});
-
-	test('handles empty string', () => {
-		expect(capitalizeFirstLetter('')).toBe('');
-	});
-
-	test('only capitalizes first letter of multi-word string', () => {
-		expect(capitalizeFirstLetter('hello world')).toBe('Hello world');
 	});
 });
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -3,10 +3,6 @@ export const titleCase = (s: string) =>
 
 export const camelCase = (s: string) => s.replace(/[-_]+(.)/g, (_, c) => c.toUpperCase());
 
-export const capitalizeFirstLetter = (str: string) => {
-	return String(str).charAt(0).toUpperCase() + String(str).slice(1);
-};
-
 export const isNumeric = (num: string | number) =>
 	(typeof num === 'number' || (typeof num === 'string' && num.trim() !== '')) &&
 	!isNaN(num as number);

--- a/src/lib/utils/meteo.test.ts
+++ b/src/lib/utils/meteo.test.ts
@@ -6,7 +6,6 @@ import {
 	countPressureVariables,
 	countPreviousVariables,
 	countVariables,
-	geoLocationNameToRoute,
 	getWeatherCode,
 	membersPerModel
 } from './meteo';
@@ -80,32 +79,6 @@ describe('getWeatherCode', () => {
 
 	test('handles string code by converting to number', () => {
 		expect(getWeatherCode('45')).toBe('fog');
-	});
-});
-
-describe('geoLocationNameToRoute', () => {
-	test('strips diacritics', () => {
-		expect(geoLocationNameToRoute('são-paolo')).toBe('sao-paolo');
-	});
-
-	test('replaces apostrophes with hyphens', () => {
-		expect(geoLocationNameToRoute("xi'an")).toBe('xi-an');
-	});
-
-	test('replaces spaces with hyphens', () => {
-		expect(geoLocationNameToRoute('new taipei city')).toBe('new-taipei-city');
-	});
-
-	test('lowercases uppercase input', () => {
-		expect(geoLocationNameToRoute('Berlin')).toBe('berlin');
-	});
-
-	test('handles multiple diacritics', () => {
-		expect(geoLocationNameToRoute('Zürich')).toBe('zurich');
-	});
-
-	test('handles already clean input', () => {
-		expect(geoLocationNameToRoute('london')).toBe('london');
 	});
 });
 

--- a/src/lib/utils/meteo.ts
+++ b/src/lib/utils/meteo.ts
@@ -160,11 +160,6 @@ export function getWeatherCode(code: number | null | string): string {
 	return 'unknown code';
 }
 
-export const geoLocationNameToRoute = (name: string) => {
-	const lowerCase = name.toLowerCase().replaceAll(' ', '-').replaceAll("'", '-');
-	return lowerCase.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-};
-
 export const membersPerModel = (model: string): number => {
 	switch (model) {
 		// DWD ICON


### PR DESCRIPTION
Removes genuinely dead code: exported functions never called in production, persisted
stores never imported, and a Cypress test selector that matched nothing.

### Changes

| File | Change |
|---|---|
| `src/lib/utils/index.ts` + test | Remove `capitalizeFirstLetter` —> exported but never used outside its own test |
| `src/lib/utils/meteo.ts` + test | Remove `geoLocationNameToRoute` —> exported but never used outside its own test |
| `src/lib/stores/settings.ts` | Remove 6 dead persisted stores —> `units`, `model`, `theme`, `themeIsDark`, `defaultLocation`, `storedLocation`; zero imports across the entire codebase |
| `src/lib/components/header/darkmode-toggle/darkmode-toggle.cy.ts` | Fix selector `#darkmode_toggle` → `[aria-label="Toggle theme"]` —> no element had the old ID, test would fail at runtime |

### Verification

- **`svelte-check`**: 0 errors, 0 warnings
- **`vitest run`**: 113/113 tests pass
- **`npm run build`**: Full production build succeeds, all 39 routes prerendered
- **Grep confirmations**: Each removed symbol confirmed zero references outside its own definition/test