### PR TITLE
chore: remove commented out CSS rule

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -468,7 +468,3 @@ figcaption {
 .dark .highlight-row:hover {
 	box-shadow: 0px 0px 5px 2px rgb(70, 70, 70, 1);
 }
-
-.highlight-row:hover .highlight-row-label {
-	/* text-decoration: underline; */
-}


### PR DESCRIPTION
Found a dead CSS rule that was completely commented out in app.css. Just cleaning it up.