### PR TITLE
chore: add lang=ts to +error.svelte

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { mode } from 'mode-watcher';
 
 	import { page } from '$app/state';


### PR DESCRIPTION
The error page script tag was missing lang="ts" so it was being treated as plain JavaScript instead of TypeScript. Just adding the attribute.