### PR TITLE
fix: countPreviousVariables iteration crash when param is string

### DIFF
--- a/src/lib/utils/meteo.ts
+++ b/src/lib/utils/meteo.ts
@@ -36,7 +36,8 @@ export const countPreviousVariables = (
 
 	let active = 0;
 	if (param) {
-		for (const p of param) {
+		const params = Array.isArray(param) ? param : [param];
+		for (const p of params) {
 			for (const fV of flattenedVariables) {
 				if (p.startsWith(fV)) {
 					active += 1;


### PR DESCRIPTION
The function assumed param would always be an array and used for...of directly on it. When a single string was passed, the loop would iterate over each character instead of treating it as one value. Added an Array.isArray check so it handles both cases.