### PR TITLE
fix: null-safe objectDifference handling falsy values (0, false)

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -37,7 +37,7 @@ export function objectDifference<T extends Record<string, unknown>>(a: T, b: T):
 			}
 			diff[key] = a[key];
 		} else {
-			if (a[key] && a[key] != '' && a[key] !== b[key]) {
+			if (a[key] !== undefined && a[key] !== null && a[key] !== '' && a[key] !== b[key]) {
 				diff[key] = a[key];
 			}
 		}


### PR DESCRIPTION
The function used if (a[key] && ...) which meant any falsy value like 0 or false was treated as if the key didnt exist and got excluded from the diff. Changed it to explicitly check for undefined and null instead so valid falsy values are properly included.