### PR TITLE
fix: update eu aqi and correct us values

### DIFF
--- a/src/routes/en/docs/air-quality-api/+page.svelte
+++ b/src/routes/en/docs/air-quality-api/+page.svelte
@@ -153,18 +153,10 @@
 				<div>
 					<p>
 						<small class="text-muted-foreground"
-							>Note: The European Air Quality Index (AQI) ranges from 0-20 (good), 20-40 (fair),
-							40-60 (moderate), 60-80 (poor), 80-100 (very poor) and exceeds 100 for extremely poor
-							conditions.</small
-						>
-					</p>
-					<p>
-						<small class="text-muted-foreground"
-							>Pollutant thresholds in μg/m³ from the <a
-								href="https://airindex.eea.europa.eu/AQI/index.html"
+							>Pollutant thresholds from the <a href="https://airindex.eea.europa.eu/AQI/index.html"
 								>European Environment Agency (EEA)</a
-							> are given on the right, using the bands revised in 2024. Hourly concentrations are used
-							for all five pollutants.</small
+							> are given below, using the bands revised in 2024. Hourly concentrations are used for all
+							five pollutants.</small
 						>
 					</p>
 				</div>
@@ -172,16 +164,14 @@
 					<div class="-mx-6 overflow-auto md:ml-0 lg:mx-0">
 						<table class="docs-table w-full min-w-200" id="airquality_table">
 							<caption
-								>You can find the update timings in the <a
-									class="text-link underline"
-									href="/en/docs/model-updates">model updates documentation</a
-								>.</caption
+								>Index values are interpolated between the thresholds of each band. The overall
+								European AQI is the highest of the five pollutant indices and can exceed 100.</caption
 							>
 							<thead>
 								<tr>
-									<th scope="col">Pollutant <small class="text-muted-foreground">(μg/m³)</small></th
+									<th scope="col"
+										>Pollutant <small class="text-muted-foreground">(hourly)</small></th
 									>
-									<th scope="col">Timespan</th>
 									<th scope="col">Good</th>
 									<th scope="col">Fair</th>
 									<th scope="col">Moderate</th>
@@ -189,11 +179,21 @@
 									<th scope="col">Very poor</th>
 									<th scope="col">Extremely poor</th>
 								</tr>
+								<tr>
+									<th scope="col">AQI</th>
+									<th scope="col">0-20</th>
+									<th scope="col">20-40</th>
+									<th scope="col">40-60</th>
+									<th scope="col">60-80</th>
+									<th scope="col">80-100</th>
+									<th scope="col">&gt;100</th>
+								</tr>
 							</thead>
 							<tbody>
 								<tr>
-									<th scope="row">PM<sub>2.5</sub></th>
-									<td>1h</td>
+									<th scope="row"
+										>PM<sub>2.5</sub> <small class="text-muted-foreground">(μg/m³)</small></th
+									>
 									<td>0-5</td>
 									<td>5-15</td>
 									<td>15-50</td>
@@ -202,8 +202,9 @@
 									<td>&gt;140</td>
 								</tr>
 								<tr>
-									<th scope="row">PM<sub>10</sub></th>
-									<td>1h</td>
+									<th scope="row"
+										>PM<sub>10</sub> <small class="text-muted-foreground">(μg/m³)</small></th
+									>
 									<td>0-15</td>
 									<td>15-45</td>
 									<td>45-120</td>
@@ -212,8 +213,9 @@
 									<td>&gt;270</td>
 								</tr>
 								<tr>
-									<th scope="row">NO<sub>2</sub></th>
-									<td>1h</td>
+									<th scope="row"
+										>NO<sub>2</sub> <small class="text-muted-foreground">(μg/m³)</small></th
+									>
 									<td>0-10</td>
 									<td>10-25</td>
 									<td>25-60</td>
@@ -222,8 +224,9 @@
 									<td>&gt;150</td>
 								</tr>
 								<tr>
-									<th scope="row">O<sub>3</sub></th>
-									<td>1h</td>
+									<th scope="row"
+										>O<sub>3</sub> <small class="text-muted-foreground">(μg/m³)</small></th
+									>
 									<td>0-60</td>
 									<td>60-100</td>
 									<td>100-120</td>
@@ -232,8 +235,9 @@
 									<td>&gt;180</td>
 								</tr>
 								<tr>
-									<th scope="row">SO<sub>2</sub></th>
-									<td>1h</td>
+									<th scope="row"
+										>SO<sub>2</sub> <small class="text-muted-foreground">(μg/m³)</small></th
+									>
 									<td>0-20</td>
 									<td>20-40</td>
 									<td>40-125</td>
@@ -260,13 +264,6 @@
 				<div>
 					<p>
 						<small class="text-muted-foreground"
-							>Note: The United States Air Quality Index (AQI) ranges from 0-50 (good), 51-100
-							(moderate), 101-150 (unhealthy for sensitive groups), 151-200 (unhealthy), 201-300
-							(very unhealthy) and 301-500 (hazardous).</small
-						>
-					</p>
-					<p>
-						<small class="text-muted-foreground"
 							>Pollutant thresholds from the <a
 								href="https://en.wikipedia.org/wiki/Air_quality_index#United_States"
 								>United States Environmental Protection Agency (EPA)</a
@@ -287,6 +284,10 @@
 				<div>
 					<div class="-mx-6 overflow-auto md:ml-0 lg:mx-0">
 						<table class="docs-table w-full min-w-200" id="airquality_table_us">
+							<caption
+								>Index values are interpolated between the thresholds of each band. The overall
+								United States AQI is the highest of the six pollutant indices and can exceed 500.</caption
+							>
 							<thead>
 								<tr>
 									<th scope="col">Pollutant</th>
@@ -297,6 +298,16 @@
 									<th scope="col">Unhealthy</th>
 									<th scope="col">Very Unhealthy</th>
 									<th scope="col" colspan="2">Hazardous</th>
+								</tr>
+								<tr>
+									<th scope="col" colspan="2">AQI</th>
+									<th scope="col">0-50</th>
+									<th scope="col">51-100</th>
+									<th scope="col">101-150</th>
+									<th scope="col">151-200</th>
+									<th scope="col">201-300</th>
+									<th scope="col">301-400</th>
+									<th scope="col">401-500</th>
 								</tr>
 							</thead>
 							<tbody>
@@ -1042,61 +1053,106 @@
 </div>
 
 <style>
-	#airquality_table tbody td:nth-child(3) {
+	/* Both tables list six classifications, so size the columns to put the colour
+	   blocks in the same place. The two US "Hazardous" ranges share the width of a
+	   single classification, and the US pollutant and timespan columns together
+	   match the width of the European pollutant column. */
+	#airquality_table thead tr:first-child th:first-child {
+		width: 16%;
+	}
+
+	#airquality_table thead tr:first-child th:not(:first-child) {
+		width: 14%;
+	}
+
+	#airquality_table_us thead tr:first-child th:nth-child(1) {
+		width: 11%;
+	}
+
+	#airquality_table_us thead tr:first-child th:nth-child(2) {
+		width: 5%;
+	}
+
+	#airquality_table_us thead tr:first-child th:nth-child(n + 3) {
+		width: 14%;
+	}
+
+	#airquality_table_us tbody td:nth-child(8),
+	#airquality_table_us tbody td:nth-child(9) {
+		width: 7%;
+	}
+
+	/* The AQI row is the last header row. Its cells line up with the body cells
+	   one column to the left in the US table, where the "AQI" label spans both the
+	   pollutant and timespan columns. */
+	#airquality_table thead tr:last-child th:nth-child(2),
+	#airquality_table tbody td:nth-child(2) {
 		background-color: rgba(80, 240, 230, 1);
 		color: #333;
 	}
 
-	#airquality_table tbody td:nth-child(4) {
+	#airquality_table thead tr:last-child th:nth-child(3),
+	#airquality_table tbody td:nth-child(3) {
 		background-color: rgba(80, 204, 170, 1);
 		color: white;
 	}
 
-	#airquality_table tbody td:nth-child(5) {
+	#airquality_table thead tr:last-child th:nth-child(4),
+	#airquality_table tbody td:nth-child(4) {
 		background-color: rgba(240, 230, 65, 1);
 		color: #333;
 	}
 
-	#airquality_table tbody td:nth-child(6) {
+	#airquality_table thead tr:last-child th:nth-child(5),
+	#airquality_table tbody td:nth-child(5) {
 		background-color: rgba(255, 80, 80, 1);
 		color: white;
 	}
 
-	#airquality_table tbody td:nth-child(7) {
+	#airquality_table thead tr:last-child th:nth-child(6),
+	#airquality_table tbody td:nth-child(6) {
 		background-color: rgba(150, 0, 50, 1);
 		color: white;
 	}
 
-	#airquality_table tbody td:nth-child(8) {
+	#airquality_table thead tr:last-child th:nth-child(7),
+	#airquality_table tbody td:nth-child(7) {
 		background-color: rgba(125, 33, 129, 1);
 		color: white;
 	}
 
+	#airquality_table_us thead tr:last-child th:nth-child(2),
 	#airquality_table_us tbody td:nth-child(3) {
 		background-color: rgba(80, 204, 170, 1);
 		color: white;
 	}
 
+	#airquality_table_us thead tr:last-child th:nth-child(3),
 	#airquality_table_us tbody td:nth-child(4) {
 		background-color: rgba(240, 230, 65, 1);
 		color: #333;
 	}
 
+	#airquality_table_us thead tr:last-child th:nth-child(4),
 	#airquality_table_us tbody td:nth-child(5) {
 		background-color: rgb(240, 167, 65);
 		color: #333;
 	}
 
+	#airquality_table_us thead tr:last-child th:nth-child(5),
 	#airquality_table_us tbody td:nth-child(6) {
 		background-color: rgba(255, 80, 80, 1);
 		color: white;
 	}
 
+	#airquality_table_us thead tr:last-child th:nth-child(6),
 	#airquality_table_us tbody td:nth-child(7) {
 		background-color: rgba(150, 0, 50, 1);
 		color: white;
 	}
 
+	#airquality_table_us thead tr:last-child th:nth-child(7),
+	#airquality_table_us thead tr:last-child th:nth-child(8),
 	#airquality_table_us tbody td:nth-child(8),
 	#airquality_table_us tbody td:nth-child(9) {
 		background-color: rgba(125, 33, 129, 1);

--- a/src/routes/en/docs/air-quality-api/+page.svelte
+++ b/src/routes/en/docs/air-quality-api/+page.svelte
@@ -161,10 +161,10 @@
 					<p>
 						<small class="text-muted-foreground"
 							>Pollutant thresholds in μg/m³ from the <a
-								href="https://www.eea.europa.eu/themes/air/air-quality-index"
-								>European Environment Agency (EAA)</a
-							> are given on the right. Particulate Matter (PM) uses a rolling average over the preceding
-							24 hours, while gases use hourly values.</small
+								href="https://airindex.eea.europa.eu/AQI/index.html"
+								>European Environment Agency (EEA)</a
+							> are given on the right, using the bands revised in 2024. Hourly concentrations are used
+							for all five pollutants.</small
 						>
 					</p>
 				</div>
@@ -193,53 +193,53 @@
 							<tbody>
 								<tr>
 									<th scope="row">PM<sub>2.5</sub></th>
-									<td>24h</td>
-									<td>0-10</td>
-									<td>10-20</td>
-									<td>20-25</td>
-									<td>25-50</td>
-									<td>50-75</td>
-									<td>75-800</td>
+									<td>1h</td>
+									<td>0-5</td>
+									<td>5-15</td>
+									<td>15-50</td>
+									<td>50-90</td>
+									<td>90-140</td>
+									<td>&gt;140</td>
 								</tr>
 								<tr>
 									<th scope="row">PM<sub>10</sub></th>
-									<td>24h</td>
-									<td>0-20</td>
-									<td>20-40</td>
-									<td>40-50</td>
-									<td>50-100</td>
-									<td>100-150</td>
-									<td>150-1200</td>
+									<td>1h</td>
+									<td>0-15</td>
+									<td>15-45</td>
+									<td>45-120</td>
+									<td>120-195</td>
+									<td>195-270</td>
+									<td>&gt;270</td>
 								</tr>
 								<tr>
 									<th scope="row">NO<sub>2</sub></th>
 									<td>1h</td>
-									<td>0-40</td>
-									<td>40-90</td>
-									<td>90-120</td>
-									<td>120-230</td>
-									<td>230-340</td>
-									<td>340-1000</td>
+									<td>0-10</td>
+									<td>10-25</td>
+									<td>25-60</td>
+									<td>60-100</td>
+									<td>100-150</td>
+									<td>&gt;150</td>
 								</tr>
 								<tr>
 									<th scope="row">O<sub>3</sub></th>
 									<td>1h</td>
-									<td>0-50</td>
-									<td>50-100</td>
-									<td>100-130</td>
-									<td>130-240</td>
-									<td>240-380</td>
-									<td>380-800</td>
+									<td>0-60</td>
+									<td>60-100</td>
+									<td>100-120</td>
+									<td>120-160</td>
+									<td>160-180</td>
+									<td>&gt;180</td>
 								</tr>
 								<tr>
 									<th scope="row">SO<sub>2</sub></th>
 									<td>1h</td>
-									<td>0-100</td>
-									<td>100-200</td>
-									<td>200-350</td>
-									<td>350-500</td>
-									<td>500-750</td>
-									<td>750-1250</td>
+									<td>0-20</td>
+									<td>20-40</td>
+									<td>40-125</td>
+									<td>125-190</td>
+									<td>190-275</td>
+									<td>&gt;275</td>
 								</tr>
 							</tbody>
 						</table>
@@ -335,9 +335,9 @@
 									<td>9-35.4</td>
 									<td>35.5-55.4</td>
 									<td>55.5-125.4</td>
-									<td>125.5-250.4</td>
+									<td>125.5-225.4</td>
 									<td>225.5-325.4</td>
-									<td>350.5-500</td>
+									<td>325.5-500.4</td>
 								</tr>
 								<tr>
 									<th scope="row"


### PR DESCRIPTION
# Fix EU and US air quality breakpoint tables

Fixes #1158

## EU: update to the 2024 EEA index bands

The table still carried the pre-2024 breakpoints. Updated to the bands revised by the EEA in 2024:

| Pollutant | Was | Now |
|---|---|---|
| PM2.5 | 0-10, 10-20, 20-25, 25-50, 50-75, 75-800 | 0-5, 5-15, 15-50, 50-90, 90-140, >140 |
| PM10 | 0-20, 20-40, 40-50, 50-100, 100-150, 150-1200 | 0-15, 15-45, 45-120, 120-195, 195-270, >270 |
| NO2 | 0-40, 40-90, 90-120, 120-230, 230-340, 340-1000 | 0-10, 10-25, 25-60, 60-100, 100-150, >150 |
| O3 | 0-50, 50-100, 100-130, 130-240, 240-380, 380-800 | 0-60, 60-100, 100-120, 120-160, 160-180, >180 |
| SO2 | 0-100, 100-200, 200-350, 350-500, 500-750, 750-1250 | 0-20, 20-40, 40-125, 125-190, 190-275, >275 |

The Timespan column for PM2.5 and PM10 changes from 24h to 1h. The EEA now uses hourly concentrations for all five pollutants, where PM previously used a 24h running mean. The intro text is updated to match, and the source link now points at airindex.eea.europa.eu, which is where the current bands live. Also corrects the "EAA" typo to "EEA".

The 0-20 (good) through >100 (extremely poor) index ranges are unchanged.
